### PR TITLE
WIP: Windows arm64 builds - help needed

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,8 +43,9 @@ jobs:
           - 'cpython-3.9'
           - 'cpython-3.10'
         vcvars:
-          - 'vcvars32.bat'
+          - 'vcvarsamd64_x86.bat'
           - 'vcvars64.bat'
+          - 'vcvarsamd64_arm64.bat'
         profile:
           - 'static-noopt'
           - 'shared-pgo'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,7 @@ jobs:
           - 'cpython-3.9'
           - 'cpython-3.10'
         vcvars:
-          - 'vcvarsamd64_x86.bat'
+          - 'vcvars32.bat'
           - 'vcvars64.bat'
           - 'vcvarsamd64_arm64.bat'
         profile:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -129,3 +129,4 @@ jobs:
         with:
           name: 'cpython-install-only-${{ matrix.version }}'
           path: cpython-*.tar.gz
+

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1513,6 +1513,7 @@ def build_openssl(
 
         root_32 = td / "x86"
         root_64 = td / "x64"
+        root_arm64 = td / "arm64"
 
         if arch == "x86":
             root_32.mkdir()
@@ -1533,6 +1534,17 @@ def build_openssl(
                 openssl_archive,
                 nasm_archive,
                 root_64,
+                profile,
+                jom_archive=jom_archive,
+            )
+        elif arch == "arm64":
+            root_64.mkdir()
+            build_openssl_for_arch(
+                perl_path,
+                "arm64",
+                openssl_archive,
+                nasm_archive,
+                root_arm64,
                 profile,
                 jom_archive=jom_archive,
             )

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -794,6 +794,8 @@ def hack_props(
             suffix = b"x64"
         elif arch == "win32":
             suffix = None
+        elif arch == "arm64":
+            suffix = b"arm64" # TODO check it
         else:
             raise Exception("unhandled architecture: %s" % arch)
 
@@ -1444,7 +1446,7 @@ def build_openssl_for_arch(
         prefix = "64"
     elif arch == "arm64":
         configure = "VC-WIN64-ARM"
-        prefix = "arm64" # ???
+        prefix = "arm64" # TODO check it ???
     else:
         print("invalid architecture: %s" % arch)
         sys.exit(1)

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1555,6 +1555,8 @@ def build_openssl(
 
         if arch == "x86":
             shutil.copytree(root_32 / "install" / "32", install / "openssl" / "win32")
+        elif arch == "arm64":
+            shutil.copytree(root_arm64 / "install" / "arm64", install / "openssl" / "arm64")
         else:
             shutil.copytree(root_64 / "install" / "64", install / "openssl" / "amd64")
 

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1442,6 +1442,9 @@ def build_openssl_for_arch(
     elif arch == "amd64":
         configure = "VC-WIN64A"
         prefix = "64"
+    elif arch == "arm64":
+        configure = "VC-WIN64-ARM"
+        prefix = "arm64" # ???
     else:
         print("invalid architecture: %s" % arch)
         sys.exit(1)
@@ -2001,6 +2004,9 @@ def build_cpython(
     elif arch == "x86":
         build_platform = "win32"
         build_directory = "win32"
+    elif arch == "arm64":
+        build_platform = "arm64"
+        build_directory = "arm64"
     else:
         raise ValueError("unhandled arch: %s" % arch)
 
@@ -2434,6 +2440,9 @@ def main():
         if os.environ.get("Platform") == "x86":
             target_triple = "i686-pc-windows-msvc"
             arch = "x86"
+        elif os.environ.get("Platform") == "arm64":
+            target_triple = "aarch64-pc-windows-msvc"
+            arch = "arm64"
         else:
             target_triple = "x86_64-pc-windows-msvc"
             arch = "amd64"


### PR DESCRIPTION
Hello,

I'm trying to add Windows ARM64 compatibility in your python-build-standalone. I started working with it. OpenSSL is compiled, libffi checks done, but 
https://github.com/adiantek/python-build-standalone/runs/3770671733?check_suite_focus=true#step:7:7470 why `-march64` is ignored?

And I don't know why build system is 32-bit... Build system should be `x86_64-w64-cygwin`, and host/target aarch64:
```
checking build system type... i686-pc-cygwin
checking host system type... aarch64-w64-cygwin
checking target system type... aarch64-w64-cygwin
```