### PR TITLE
Add build attestations. Closes #343

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -201,6 +201,12 @@ jobs:
             runner: macos-13
             py: 'cpython-3.13'
             options: 'freethreaded+pgo+lto'
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
     needs:
       - pythonbuild
     runs-on: ${{ matrix.build.runner }}
@@ -232,6 +238,11 @@ jobs:
           fi
 
           ./build-macos.py --target-triple ${{ matrix.build.target_triple }} --python ${{ matrix.build.py }} --options ${{ matrix.build.options }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/*
 
       - name: Upload Distributions
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -803,6 +803,11 @@ jobs:
             py: 'cpython-3.12'
             options: 'lto'
 
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
     needs:
       - pythonbuild
       - image
@@ -861,6 +866,11 @@ jobs:
           fi
 
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/*
 
       - name: Upload Distribution
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,6 +63,11 @@ jobs:
             vcvars: 'vcvars64.bat'
             options: 'freethreaded+pgo'
 
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
     needs: pythonbuild
     runs-on: 'windows-2019'
     steps:
@@ -101,6 +106,11 @@ jobs:
         run: |
           $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
           .\pythonbuild.exe validate-distribution --run $Dists
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/*
 
       - name: Upload Distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This adds build attestations for our builds, following the guides here: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-build-provenance-for-binaries

Closes #343