### PR TITLE
Require mimalloc explicitly on all GNU Python 3.13 builds

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -355,8 +355,14 @@ if [ -n "${CPYTHON_DEBUG}" ]; then
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-pydebug"
 fi
 
+# Explicitly enable mimalloc on 3.13+, it's already included by default but with this it'll fail
+# if it's missing from the system. The MUSL builds do not supprt mimalloc yet.
+if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" && "${CC}" != "musl-clang" ]]; then
+    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-mimalloc"
+fi
+
 if [ -n "${CPYTHON_FREETHREADED}" ]; then
-    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --disable-gil --with-mimalloc"
+    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --disable-gil"
 fi
 
 if [ -n "${CPYTHON_OPTIMIZED}" ]; then


### PR DESCRIPTION
Previously, it was only explicitly required for the freethreaded builds

Closes https://github.com/indygreg/python-build-standalone/issues/389