### PR TITLE
Convert to UTF-8 prior to setting Tkinter path

### DIFF
--- a/cpython-unix/patch-tkinter-3.10.patch
+++ b/cpython-unix/patch-tkinter-3.10.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 2a3e65b6c97..b17c5bfd6b1 100644
+index 2a3e65b6c97..04f2ab0ea10 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -115,6 +115,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -82,7 +82,7 @@ index 2a3e65b6c97..b17c5bfd6b1 100644
              str_path = _get_tcl_lib_path();
              if (str_path == NULL && PyErr_Occurred()) {
                  return NULL;
-@@ -3628,7 +3674,27 @@ PyInit__tkinter(void)
+@@ -3628,7 +3674,32 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
@@ -97,6 +97,11 @@ index 2a3e65b6c97..b17c5bfd6b1 100644
 +                    return NULL;
 +                }
 +                if (str_path != NULL) {
++                    path = PyUnicode_AsUTF8(str_path);
++                    if (path == NULL) {
++                        Py_DECREF(m);
++                        return NULL;
++                    }
 +                    setenv("TCL_LIBRARY", path, 1);
 +                    set_var = 1;
 +                }

--- a/cpython-unix/patch-tkinter-3.11.patch
+++ b/cpython-unix/patch-tkinter-3.11.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 005036d3ff2..c130ed7b186 100644
+index 005036d3ff2..0e64706584a 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -28,9 +28,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -93,7 +93,7 @@ index 005036d3ff2..c130ed7b186 100644
              str_path = _get_tcl_lib_path();
              if (str_path == NULL && PyErr_Occurred()) {
                  return NULL;
-@@ -3428,7 +3472,27 @@ PyInit__tkinter(void)
+@@ -3428,7 +3472,32 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
@@ -108,6 +108,11 @@ index 005036d3ff2..c130ed7b186 100644
 +                    return NULL;
 +                }
 +                if (str_path != NULL) {
++                    path = PyUnicode_AsUTF8(str_path);
++                    if (path == NULL) {
++                        Py_DECREF(m);
++                        return NULL;
++                    }
 +                    setenv("TCL_LIBRARY", path, 1);
 +                    set_var = 1;
 +                }

--- a/cpython-unix/patch-tkinter-3.12.patch
+++ b/cpython-unix/patch-tkinter-3.12.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 6b5fcb8a365..99d44ccf1d8 100644
+index 6b5fcb8a365..7b196f40166 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -28,9 +28,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -93,7 +93,7 @@ index 6b5fcb8a365..99d44ccf1d8 100644
              str_path = _get_tcl_lib_path();
              if (str_path == NULL && PyErr_Occurred()) {
                  return NULL;
-@@ -3542,7 +3586,27 @@ PyInit__tkinter(void)
+@@ -3542,7 +3586,32 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
@@ -108,6 +108,11 @@ index 6b5fcb8a365..99d44ccf1d8 100644
 +                    return NULL;
 +                }
 +                if (str_path != NULL) {
++                    path = PyUnicode_AsUTF8(str_path);
++                    if (path == NULL) {
++                        Py_DECREF(m);
++                        return NULL;
++                    }
 +                    setenv("TCL_LIBRARY", path, 1);
 +                    set_var = 1;
 +                }

--- a/cpython-unix/patch-tkinter-3.13.patch
+++ b/cpython-unix/patch-tkinter-3.13.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 45897817a56..671b3dfc3d0 100644
+index 45897817a56..5633187730a 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -26,9 +26,8 @@ Copyright (C) 1994 Steen Lumholt.
@@ -94,7 +94,7 @@ index 45897817a56..671b3dfc3d0 100644
              str_path = _get_tcl_lib_path();
              if (str_path == NULL && PyErr_Occurred()) {
                  return NULL;
-@@ -3552,7 +3597,27 @@ PyInit__tkinter(void)
+@@ -3552,7 +3597,32 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
@@ -109,6 +109,11 @@ index 45897817a56..671b3dfc3d0 100644
 +                    return NULL;
 +                }
 +                if (str_path != NULL) {
++                    path = PyUnicode_AsUTF8(str_path);
++                    if (path == NULL) {
++                        Py_DECREF(m);
++                        return NULL;
++                    }
 +                    setenv("TCL_LIBRARY", path, 1);
 +                    set_var = 1;
 +                }
@@ -122,6 +127,3 @@ index 45897817a56..671b3dfc3d0 100644
  #endif /* MS_WINDOWS */
          }
          Py_XDECREF(cexe);
-diff --git a/patch-tkinter.patch b/patch-tkinter.patch
-new file mode 100644
-index 00000000000..e69de29bb2d

--- a/cpython-unix/patch-tkinter-3.9.patch
+++ b/cpython-unix/patch-tkinter-3.9.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index e153047b778..5dbaf2e3e6e 100644
+index e153047b778..02f5d12db1a 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -115,6 +115,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -82,7 +82,7 @@ index e153047b778..5dbaf2e3e6e 100644
              str_path = _get_tcl_lib_path();
              if (str_path == NULL && PyErr_Occurred()) {
                  return NULL;
-@@ -3631,7 +3677,27 @@ PyInit__tkinter(void)
+@@ -3631,7 +3677,32 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
@@ -97,6 +97,11 @@ index e153047b778..5dbaf2e3e6e 100644
 +                    return NULL;
 +                }
 +                if (str_path != NULL) {
++                    path = PyUnicode_AsUTF8(str_path);
++                    if (path == NULL) {
++                        Py_DECREF(m);
++                        return NULL;
++                    }
 +                    setenv("TCL_LIBRARY", path, 1);
 +                    set_var = 1;
 +                }


### PR DESCRIPTION
## Summary

In https://github.com/indygreg/python-build-standalone/pull/421, @carljm pointed out that `path` was uninitialized in `setenv("TCL_LIBRARY", path, 1);`. It turns out we need to set it via `PyUnicode_AsUTF8`.

I confirmed that the existing code _was_ running; it's just that`setenv` returns an error (rather than crashing), and we weren't checking the result (though the same is true in the Windows path). If you, e.g., try to `printf` `path` just before, you get a segmentation fault.

This code isn't necessary to fix the motivating Tkinter limitation, so that's another reason it wasn't caught.
