### PR TITLE
Switch to Depot runners in CI

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -46,80 +46,62 @@ jobs:
       matrix:
         build:
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.9'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.9'
             options: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.9'
             options: 'pgo+lto'
 
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.10'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.10'
             options: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.10'
             options: 'pgo+lto'
 
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.11'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.11'
             options: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.11'
             options: 'pgo+lto'
 
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.12'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.12'
             options: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.12'
             options: 'pgo+lto'
 
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'pgo+lto'
 
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'freethreaded+debug'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'freethreaded+pgo'
           - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.13'
             options: 'freethreaded+pgo+lto'
 
@@ -127,84 +109,66 @@ jobs:
           # noopt because it doesn't provide any compelling advantages over PGO
           # or LTO builds.
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.9'
             options: 'debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.9'
             options: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.9'
             options: 'pgo+lto'
 
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.10'
             options: 'debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.10'
             options: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.10'
             options: 'pgo+lto'
 
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.11'
             options: 'debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.11'
             options: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.11'
             options: 'pgo+lto'
 
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.12'
             options: 'debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.12'
             options: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.12'
             options: 'pgo+lto'
 
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'pgo+lto'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'freethreaded+debug'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'freethreaded+pgo'
           - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
             py: 'cpython-3.13'
             options: 'freethreaded+pgo+lto'
     needs:
       - pythonbuild
-    runs-on: ${{ matrix.build.runner }}
+    runs-on: depot-macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   pythonbuild:
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
     steps:
       - name: Install System Dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
           - gcc
           - xcb
           - xcb.cross
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
     permissions:
       packages: write
     steps:
@@ -725,7 +725,7 @@ jobs:
     needs:
       - pythonbuild
       - image
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1087,7 +1087,7 @@ jobs:
     needs:
       - pythonbuild
       - image
-    runs-on: ubuntu-22.04
+    runs-on: depot-ubuntu-22.04
 
     # The above should remain an exact duplicate of the `build` job
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
             options: 'freethreaded+pgo'
 
     needs: pythonbuild
-    runs-on: 'windows-latest-xlarge'
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
             options: 'freethreaded+pgo'
 
     needs: pythonbuild
-    runs-on: 'windows-latest-large'
+    runs-on: 'windows-latest-xlarge'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
             options: 'freethreaded+pgo'
 
     needs: pythonbuild
-    runs-on: 'windows-2022'
+    runs-on: 'windows-latest-large'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Otherwise, the jobs here will consume our concurrency limits and block CI organization-wide. The Depot runners will give us greater concurrency limits, and notably, avoid colliding with our GitHub Runner limits — which are very low for macOS in particular.

~Also, uses larger GitHub Actions runners for Windows.~ I've reverted this because there's a new, inexplicable [failure for 32-bit 3.12](https://github.com/astral-sh/python-build-standalone/actions/runs/12381299627/job/34559706602?pr=426) 

Note that Depot doesn't support x86_64 macOS so we're now cross-compiling those. I previously verified the artifact was correct.