### PR TITLE
Add `ci:dry-run` to skip performing builds but still test the matrix

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -90,6 +90,7 @@ jobs:
           path: build
 
       - name: Build
+        if: ${{ ! matrix.dry-run }}
         run: |
           if [ "${{ matrix.target_triple }}" = "aarch64-apple-darwin" ]; then
             export APPLE_SDK_PATH=/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk
@@ -103,18 +104,22 @@ jobs:
           ./build-macos.py --target-triple ${{ matrix.target_triple }} --python cpython-${{ matrix.python }} --options ${{ matrix.build_options }}
 
       - name: Upload Distributions
+        if: ${{ ! matrix.dry-run }}
         uses: actions/upload-artifact@v4
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
           path: dist/*
 
-      - uses: actions/checkout@v4
+      - name: Checkout macOS SDKs for validation
+        if: ${{ ! matrix.dry-run }}
+        uses: actions/checkout@v4
         with:
           repository: 'phracker/MacOSX-SDKs'
           ref: master
           path: macosx-sdks
 
       - name: Validate Distribution
+        if: ${{ ! matrix.dry-run }}
         run: |
           chmod +x build/pythonbuild
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -185,6 +185,7 @@ jobs:
           done
 
       - name: Build
+        if: ${{ ! matrix.dry-run }}
         run: |
           # Do empty target so all generated files are touched.
           ./build-linux.py --make-target empty
@@ -195,6 +196,7 @@ jobs:
           ./build-linux.py --target-triple ${{ matrix.target_triple }} --python cpython-${{ matrix.python }} --options ${{ matrix.build_options }}
 
       - name: Validate Distribution
+        if: ${{ ! matrix.dry-run }}
         run: |
           chmod +x build/pythonbuild
 
@@ -205,6 +207,7 @@ jobs:
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
 
       - name: Upload Distribution
+        if: ${{ ! matrix.dry-run }}
         uses: actions/upload-artifact@v4
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -100,12 +100,14 @@ jobs:
           py.exe -3.9 build-windows.py --help
 
       - name: Build
+        if: ${{ ! matrix.dry-run }}
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\${{ matrix.vcvars }}"
           py.exe -3.9 build-windows.py --python cpython-${{ matrix.python }} --sh c:\cygwin\bin\sh.exe --options ${{ matrix.build_options }}
 
       - name: Validate Distribution
+        if: ${{ ! matrix.dry-run }}
         run: |
           $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
           .\pythonbuild.exe validate-distribution --run $Dists


### PR DESCRIPTION
In general, I think this will be a little niche but in the short-term it'll be really helpful for iterating on our build matrix.