### PR TITLE
Skip building `pythonbuild` when not needed

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -14,6 +14,9 @@ env:
 
 jobs:
   pythonbuild:
+    if: ${{ needs.generate-matrix.outputs.pythonbuild_changed == 'true' || needs.generate-matrix.outputs.any_builds == 'true' || github.ref == 'refs/heads/main' }}
+    needs:
+      - generate-matrix
     runs-on: depot-macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      any_builds: ${{ steps.set-matrix.outputs.any_builds }}
+      pythonbuild_changed: ${{ steps.changed.outputs.pythonbuild_any_changed }}
     steps:
       - uses: actions/checkout@v4
 
@@ -64,6 +69,20 @@ jobs:
           # Display the matrix for debugging too
           cat matrix.json | jq
 
+          if jq -e '.include | length > 0' matrix.json > /dev/null; then
+            # Build matrix has entries
+            echo "any_builds=true" >> $GITHUB_OUTPUT
+          else
+            # Build matrix is empty
+            echo "any_builds=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: tj-actions/changed-files@v45
+        id: changed
+        with:
+          files_yaml: |
+            pythonbuild:
+              - "src/*.rs"
   build:
     needs:
       - generate-matrix

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,9 @@ env:
 
 jobs:
   pythonbuild:
+    if: ${{ needs.generate-matrix.outputs.pythonbuild_changed == 'true' || needs.generate-matrix.outputs.any_builds == 'true' || github.ref == 'refs/heads/main' }}
+    needs:
+      - generate-matrix
     runs-on: depot-ubuntu-22.04
     steps:
       - name: Install System Dependencies
@@ -46,9 +49,9 @@ jobs:
           path: target/release/pythonbuild
 
   image:
+    if: ${{ needs.generate-matrix.outputs.any_builds == 'true' }}
     needs:
       - generate-matrix
-    if: ${{ needs.generate-matrix.outputs.any_builds == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +126,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       any_builds: ${{ steps.set-matrix.outputs.any_builds }}
+      pythonbuild_changed: ${{ steps.changed.outputs.pythonbuild_any_changed }}
     steps:
       - uses: actions/checkout@v4
       
@@ -150,7 +154,14 @@ jobs:
             # Build matrix is empty
             echo "any_builds=false" >> $GITHUB_OUTPUT
           fi
-        
+
+      - uses: tj-actions/changed-files@v45
+        id: changed
+        with:
+          files_yaml: |
+            pythonbuild:
+              - "src/*.rs"
+
   build:
     needs:
       - generate-matrix

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,9 @@ env:
 
 jobs:
   pythonbuild:
+    if: ${{ needs.generate-matrix.outputs.pythonbuild_changed == 'true' || needs.generate-matrix.outputs.any_builds == 'true' || github.ref == 'refs/heads/main' }}
+    needs:
+      - generate-matrix
     runs-on: 'windows-2022'
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      any_builds: ${{ steps.set-matrix.outputs.any_builds }}
+      pythonbuild_changed: ${{ steps.changed.outputs.pythonbuild_any_changed }}
     steps:
       - uses: actions/checkout@v4
       
@@ -63,7 +68,22 @@ jobs:
           uv run ci-matrix.py --platform windows --labels '${{ steps.get-labels.outputs.labels }}' > matrix.json && echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
           # Display the matrix for debugging too
           cat matrix.json | jq
-      
+
+          if jq -e '.include | length > 0' matrix.json > /dev/null; then
+            # Build matrix has entries
+            echo "any_builds=true" >> $GITHUB_OUTPUT
+          else
+            # Build matrix is empty
+            echo "any_builds=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: tj-actions/changed-files@v45
+        id: changed
+        with:
+          files_yaml: |
+            pythonbuild:
+              - "src/*.rs"
+
   build:
     needs:
       - generate-matrix

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,9 +4,10 @@
 
 use std::str::FromStr;
 
-use crate::release::{bootstrap_llvm, produce_install_only_stripped};
 use {
-    crate::release::{produce_install_only, RELEASE_TRIPLES},
+    crate::release::{
+        bootstrap_llvm, produce_install_only, produce_install_only_stripped, RELEASE_TRIPLES,
+    },
     anyhow::{anyhow, Result},
     bytes::Bytes,
     clap::ArgMatches,


### PR DESCRIPTION
Only build the Rust `pythonbuild` crate if one of the following is true

- We're on `main`
- There are builds for the platform
- There are changes to the `.rs` files