### PR TITLE
Install `binutils` for Linux builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,7 +130,7 @@ jobs:
       pythonbuild_changed: ${{ steps.changed.outputs.pythonbuild_any_changed }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: astral-sh/setup-uv@v4
 
@@ -140,7 +140,7 @@ jobs:
           # Convert GitHub labels array to comma-separated string
           LABELS=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -r 'join(",")')
           echo "labels=$LABELS" >> $GITHUB_OUTPUT
-          
+
       - name: Generate build matrix
         id: set-matrix
         run: |
@@ -207,6 +207,10 @@ jobs:
             echo "loading $f"
             docker load --input $f
           done
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install binutils
 
       - name: Build
         if: ${{ ! matrix.dry-run }}


### PR DESCRIPTION
Linux cross-compiles are failing on `main` @ https://github.com/astral-sh/python-build-standalone/commit/01cfc3b2dff416f2390cb6d45faa67a384abc644 due to `readelf` missing?