### PR TITLE
Apply readelf patch for cross-compiling on older Python versions

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -80,6 +80,13 @@ if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
     fi
 fi
 
+# disable readelf check when cross-compiling on older Python versions
+if [ -n "${CROSS_COMPILING}" ]; then
+    if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
+        patch -p1 -i ${ROOT}/patch-cross-readelf.patch
+    fi
+fi
+
 # This patch is slightly different on Python 3.10+.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_10}" ]; then
     patch -p1 -i ${ROOT}/patch-xopen-source-ios.patch

--- a/cpython-unix/patch-apple-cross.patch
+++ b/cpython-unix/patch-apple-cross.patch
@@ -71,22 +71,6 @@ index c62a565eb6..7e5d34632c 100644
      	LDLIBRARY='libpython$(LDVERSION).dylib'
  	BLDLIBRARY='-L. -lpython$(LDVERSION)'
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
-@@ -1626,15 +1665,6 @@ then
- fi
- 
- AC_CHECK_TOOLS([READELF], [readelf], [:])
--if test "$cross_compiling" = yes; then
--    case "$READELF" in
--	readelf|:)
--	AC_MSG_ERROR([readelf for the host is required for cross builds])
--	;;
--    esac
--fi
--AC_SUBST(READELF)
--
- 
- case $MACHDEP in
- hp*|HP*)
 @@ -3173,6 +3203,11 @@ then
  	Linux*|GNU*|QNX*|VxWorks*|Haiku*)
  		LDSHARED='$(CC) -shared'

--- a/cpython-unix/patch-cross-readelf.patch
+++ b/cpython-unix/patch-cross-readelf.patch
@@ -1,0 +1,20 @@
+diff --git a/configure.ac b/configure.ac
+index c62a565eb6..7e5d34632c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1626,15 +1665,6 @@ then
+ fi
+ 
+ AC_CHECK_TOOLS([READELF], [readelf], [:])
+-if test "$cross_compiling" = yes; then
+-    case "$READELF" in
+-	readelf|:)
+-	AC_MSG_ERROR([readelf for the host is required for cross builds])
+-	;;
+-    esac
+-fi
+-AC_SUBST(READELF)
+-
+ 
+ case $MACHDEP in
+ hp*|HP*)


### PR DESCRIPTION
Linux cross-compiles are failing on `main` @ https://github.com/astral-sh/python-build-standalone/commit/01cfc3b2dff416f2390cb6d45faa67a384abc644 due to `readelf` missing. We drop this check as part of the Apple cross compilation patch but since #443 we no longer apply that patch on Linux. This moves the patch out into a separate file and applies it when cross-compiling on Python <=3.12 where it is relevant.