### PR TITLE
Add missing parser files to Python 3.13 Linux and macOS builds

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -989,7 +989,7 @@ ${BUILD_PYTHON} ${ROOT}/fix_shebangs.py ${ROOT}/out/python/install
 
 # Also copy object files so they can be linked in a custom manner by
 # downstream consumers.
-OBJECT_DIRS="Objects Parser Parser/pegen Programs Python Python/deepfreeze"
+OBJECT_DIRS="Objects Parser Parser/lexer Parser/pegen Parser/tokenizer Programs Python Python/deepfreeze"
 OBJECT_DIRS="${OBJECT_DIRS} Modules"
 for ext in _blake2 cjkcodecs _ctypes _ctypes/darwin _decimal _expat _hacl _io _multiprocessing _sha3 _sqlite _sre _testinternalcapi _xxtestfuzz ; do
     OBJECT_DIRS="${OBJECT_DIRS} Modules/${ext}"


### PR DESCRIPTION
This PR fixes the CPython 3.13 distributions on Linux and macOS builds to include the additional object files in subdirectories of the `Parser` directory. Will fix #378 when merged.

Windows builds are unaffected by the bug because the Windows build script uses a different mechanism to collect the object files.