### PR TITLE
ci: enable PGO on x86-64-v4

### DIFF
--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -218,14 +218,13 @@ linux:
       - "3.14"
     build_options:
       - debug
-      - noopt
-      - lto
+      - pgo+lto
     build_options_conditional:
       - options:
           - freethreaded+debug
-          - freethreaded+noopt
-          - freethreaded+lto
+          - freethreaded+pgo+lto
         minimum-python-version: "3.13"
+    run: true
 
   x86_64-unknown-linux-musl:
     arch: x86_64
@@ -288,6 +287,7 @@ linux:
       - debug
       - noopt
       - lto
+    run: true
 
 windows:
   i686-pc-windows-msvc:


### PR DESCRIPTION
The GitHub Actions x86-64 runners are using ancient Azure instances
that lack AVX-512. As a result we can't run x86-64-v4 binaries. As
a result we can't perform PGO/BOLT nor run tests using the built
interpreter.

We recently adopted custom runners. Whatever hardware they are
using under the hood appears to support AVX-512 and therefore
the x86-64-v4 instruction set. So we're able to enable PGO
and running tests.

This will theoretically deliver performance wins for the x86-64-v4
builds. But I haven't performed comprehensive testing.