### PR TITLE
unix: refresh test_embed patches to conditionally skip on BOLT

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -305,7 +305,7 @@ fi
 # On 3.12 (minimum BOLT version), the segfault causes the test harness to
 # abort and BOLT optimization uses the partial test results. On 3.13, the segfault
 # is a fatal error.
-if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_10}" ]; then
+if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
     patch -p1 -i ${ROOT}/patch-test-embed-prevent-segfault.patch
 fi
 

--- a/cpython-unix/patch-test-embed-prevent-segfault-3.14.patch
+++ b/cpython-unix/patch-test-embed-prevent-segfault-3.14.patch
@@ -1,12 +1,12 @@
 diff --git a/Lib/test/test_embed.py b/Lib/test/test_embed.py
-index 7110fb889f3..61e4d0f6179 100644
+index 7110fb889f3..1b55cd156d7 100644
 --- a/Lib/test/test_embed.py
 +++ b/Lib/test/test_embed.py
 @@ -940,6 +940,7 @@ def check_all_configs(self, testname, expected_config=None,
          self.check_global_config(configs)
          return configs
  
-+    @unittest.skip("segfaults on BOLT instrumented binaries")
++    @unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
      def test_init_default_config(self):
          self.check_all_configs("test_init_initialize_config", api=API_COMPAT)
  
@@ -14,7 +14,7 @@ index 7110fb889f3..61e4d0f6179 100644
          self.check_all_configs("test_init_from_config", config, preconfig,
                                 api=API_COMPAT)
  
-+    @unittest.skip("segfaults on BOLT instrumented binaries")
++    @unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
      def test_init_compat_env(self):
          preconfig = {
              'allocator': ALLOCATOR_FOR_CONFIG,
@@ -22,7 +22,7 @@ index 7110fb889f3..61e4d0f6179 100644
          self.check_all_configs("test_init_compat_env", config, preconfig,
                                 api=API_COMPAT)
  
-+    @unittest.skip("segfaults on BOLT instrumented binaries")
++    @unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
      def test_init_python_env(self):
          preconfig = {
              'allocator': ALLOCATOR_FOR_CONFIG,
@@ -30,7 +30,7 @@ index 7110fb889f3..61e4d0f6179 100644
          self.check_all_configs("test_init_set_config", config,
                                 api=API_ISOLATED)
  
-+    @unittest.skip("segfaults on BOLT instrumented binaries")
++    @unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
      def test_initconfig_api(self):
          preconfig = {
              'configure_locale': True,

--- a/cpython-unix/patch-test-embed-prevent-segfault.patch
+++ b/cpython-unix/patch-test-embed-prevent-segfault.patch
@@ -1,12 +1,12 @@
 diff --git a/Lib/test/test_embed.py b/Lib/test/test_embed.py
-index 13713cf37b8..ba23880b15f 100644
+index 13713cf37b8..40ee4837bfe 100644
 --- a/Lib/test/test_embed.py
 +++ b/Lib/test/test_embed.py
 @@ -1615,6 +1615,7 @@ def test_getpath_abspath_win32(self):
          for (_, expected), result in zip(CASES, results):
              self.assertEqual(result, expected)
  
-+    @unittest.skip("segfaults on BOLT instrumented binaries")
++    @unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
      def test_global_pathconfig(self):
          # Test C API functions getting the path configuration:
          #
@@ -14,7 +14,7 @@ index 13713cf37b8..ba23880b15f 100644
                  self.assertEqual(blocks, 0, out)
  
  
-+@unittest.skip("segfaults on BOLT instrumented binaries")
++@unittest.skipIf(support.check_bolt_optimized, "segfaults on BOLT instrumented binaries")
  class StdPrinterTests(EmbeddingTestsMixin, unittest.TestCase):
      # Test PyStdPrinter_Type which is used by _PySys_SetPreliminaryStderr():
      #   "Set up a preliminary stderr printer until we have enough


### PR DESCRIPTION
Turns out there is a support function to check for BOLT optimization. So we can conditionally skip tests on BOLT.

Closes #465.