### PR TITLE
Bump Docker timeout from 60s to 10m

### DIFF
--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -933,7 +933,7 @@ def main():
         client = None
     else:
         try:
-            client = docker.from_env()
+            client = docker.from_env(timeout=180)
             client.ping()
         except Exception as e:
             print("unable to connect to Docker: %s" % e, file=sys.stderr)

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -933,7 +933,7 @@ def main():
         client = None
     else:
         try:
-            client = docker.from_env(timeout=180)
+            client = docker.from_env(timeout=600)
             client.ping()
         except Exception as e:
             print("unable to connect to Docker: %s" % e, file=sys.stderr)


### PR DESCRIPTION
See https://github.com/docker/docker-py/issues/2266

I'm encountering the 60s timeout copying archives in/out of images on a slower disk.