### PR TITLE
Update expected release triples for `x86_64_v4`

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -271,12 +271,12 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "x86_64_v4-unknown-linux-gnu",
         TripleRelease {
-            suffixes: linux_suffixes_nopgo.clone(),
-            install_only_suffix: "lto",
+            suffixes: linux_suffixes_pgo.clone(),
+            install_only_suffix: "pgo+lto",
             python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
             conditional_suffixes: vec![ConditionalSuffixes {
                 python_version_requirement: VersionSpecifier::from_str(">=3.13").unwrap(),
-                suffixes: linux_suffixes_nopgo_freethreaded.clone(),
+                suffixes: linux_suffixes_pgo_freethreaded.clone(),
             }],
         },
     );


### PR DESCRIPTION
Following up on https://github.com/astral-sh/python-build-standalone/pull/467