### PR TITLE
Fix musl Linux release targets

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -281,12 +281,13 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
             }],
         },
     );
+    // TODO: Python 3.14 support on musl
     h.insert(
         "x86_64-unknown-linux-musl",
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: None,
+            python_version_requirement: Some(VersionSpecifier::from_str("<3.14").unwrap()),
             conditional_suffixes: vec![],
         },
     );
@@ -295,7 +296,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str("<3.14").unwrap()),
             conditional_suffixes: vec![],
         },
     );
@@ -304,7 +305,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str("<3.14").unwrap()),
             conditional_suffixes: vec![],
         },
     );
@@ -313,7 +314,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str("<3.14").unwrap()),
             conditional_suffixes: vec![],
         },
     );

--- a/src/release.rs
+++ b/src/release.rs
@@ -284,8 +284,8 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "x86_64-unknown-linux-musl",
         TripleRelease {
-            suffixes: linux_suffixes_pgo.clone(),
-            install_only_suffix: "pgo+lto",
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
             python_version_requirement: None,
             conditional_suffixes: vec![],
         },
@@ -293,8 +293,8 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "x86_64_v2-unknown-linux-musl",
         TripleRelease {
-            suffixes: linux_suffixes_pgo.clone(),
-            install_only_suffix: "pgo+lto",
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
             python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
             conditional_suffixes: vec![],
         },
@@ -302,8 +302,8 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "x86_64_v3-unknown-linux-musl",
         TripleRelease {
-            suffixes: linux_suffixes_pgo.clone(),
-            install_only_suffix: "pgo+lto",
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
             python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
             conditional_suffixes: vec![],
         },
@@ -311,8 +311,8 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "x86_64_v4-unknown-linux-musl",
         TripleRelease {
-            suffixes: linux_suffixes_pgo.clone(),
-            install_only_suffix: "pgo+lto",
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
             python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
             conditional_suffixes: vec![],
         },


### PR DESCRIPTION
- **Revert "Update release targets for x86_64 musl (#477)"**
- **Drop 3.14 from expected musl Linux release targets**
