### PR TITLE
Fix x86_64-apple-darwin comment in targets.yml

### DIFF
--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -552,7 +552,7 @@ thumb7k-apple-watchos:
 
 # Intel macOS.
 #
-# We target compatibility with macOS 10.9+ for compatibility with older Apple
+# We target compatibility with macOS 10.15+ for compatibility with older Apple
 # machines.
 x86_64-apple-darwin:
   host_platforms:


### PR DESCRIPTION
Hi all,

just fixing an outdated comment about the min macOS version for the `x86_64-apple-darwin` target.

Thanks for maintaining this project!