### PR TITLE
Add Python 3.14 support on Windows

### DIFF
--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -320,6 +320,7 @@ windows:
       - "3.11"
       - "3.12"
       - "3.13"
+      - "3.14"
     build_options:
       - pgo
     build_options_conditional:
@@ -336,6 +337,7 @@ windows:
       - "3.11"
       - "3.12"
       - "3.13"
+      - "3.14"
     build_options:
       - pgo
     build_options_conditional:

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -573,10 +573,13 @@ def hack_project_files(
         rb'<ClCompile Include="$(opensslIncludeDir)\openssl\applink.c">',
     )
 
-    # We're still on the pre-built tk-windows-bin 8.6.12 which doesn't have a
-    # standalone zlib DLL. So remove references to it from 3.12+.
-    # On 3.14, something changed
-    if meets_python_minimum_version(python_version, "3.12") and meets_python_maximum_version(python_version, "3.13"):
+    # Python 3.12+ uses the the pre-built tk-windows-bin 8.6.12 which doesn't
+    # have a standalone zlib DLL, so we remove references to it. For Python
+    # 3.14+, we're using tk-windows-bin 8.6.14 which includes a prebuilt zlib
+    # DLL, so we skip this patch there.
+    if meets_python_minimum_version(
+        python_version, "3.12"
+    ) and meets_python_maximum_version(python_version, "3.13"):
         static_replace_in_file(
             pcbuild_path / "_tkinter.vcxproj",
             rb'<_TclTkDLL Include="$(tcltkdir)\bin\$(tclZlibDllName)" />',

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -568,7 +568,8 @@ def hack_project_files(
 
     # We're still on the pre-built tk-windows-bin 8.6.12 which doesn't have a
     # standalone zlib DLL. So remove references to it from 3.12+.
-    if meets_python_minimum_version(python_version, "3.12"):
+    # On 3.14, something changed
+    if meets_python_minimum_version(python_version, "3.12") and meets_python_maximum_version(python_version, "3.13"):
         static_replace_in_file(
             pcbuild_path / "_tkinter.vcxproj",
             rb'<_TclTkDLL Include="$(tcltkdir)\bin\$(tclZlibDllName)" />',
@@ -1690,6 +1691,7 @@ def main() -> None:
             "cpython-3.11",
             "cpython-3.12",
             "cpython-3.13",
+            "cpython-3.14",
         },
         default="cpython-3.11",
         help="Python distribution to build",

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -798,6 +798,8 @@ const GLOBAL_EXTENSIONS_WINDOWS: &[&str] = &[
     "winsound",
 ];
 
+const GLOBAL_EXTENSIONS_WINDOWS_3_14: &[&str] = &["_wmi"];
+
 const GLOBAL_EXTENSIONS_WINDOWS_PRE_3_13: &[&str] = &["_msi"];
 
 /// Extension modules not present in Windows static builds.
@@ -1540,6 +1542,10 @@ fn validate_extension_modules(
 
         if matches!(python_major_minor, "3.9" | "3.10" | "3.11" | "3.12") {
             wanted.extend(GLOBAL_EXTENSIONS_WINDOWS_PRE_3_13);
+        }
+
+        if matches!(python_major_minor, "3.14") {
+            wanted.extend(GLOBAL_EXTENSIONS_WINDOWS_3_14);
         }
 
         if static_crt {


### PR DESCRIPTION
The upstream build system now requires the latest tcl/tk and we want to upgrade anyway, so that happens here as well. There are some concerns about the new zlib/msvcrt dependencies, so I'm limiting these to the 3.14a to see how it goes.

See #495 