### PR TITLE
Build attestations improvements

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,6 +245,12 @@ jobs:
 
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
 
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          subject-path: dist/*
+
       - name: Upload Distribution
         if: ${{ ! matrix.dry-run }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ env:
 permissions:
   contents: write
   packages: write
+  # Permissions used for actions/attest-build-provenance
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -75,3 +78,9 @@ jobs:
       # Uploading the relevant artifact to the GitHub release.
       - run: just release-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}
         if: ${{ github.event.inputs.dry-run == 'false' }}
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2
+        if: ${{ github.event.inputs.dry-run == 'false' }}
+        with:
+          subject-path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,4 @@ jobs:
         uses: actions/attest-build-provenance@v2
         if: ${{ github.event.inputs.dry-run == 'false' }}
         with:
-          subject-path: dist/*
+          subject-path: dist/*.tar.@(zst|gz)


### PR DESCRIPTION
Per https://github.com/astral-sh/python-build-standalone/issues/343#issuecomment-2598666478

* Adds attestations to build-0 of the linux matrix (due to recent refactor)
* Adds attestations to release artifacts which include install only derived builds.