### PR TITLE
Fix virtual environment creation when bootstrapping build environments with a standalone Python

### DIFF
--- a/build-linux.py
+++ b/build-linux.py
@@ -21,7 +21,7 @@ MAKE_DIR = ROOT / "cpython-unix"
 def bootstrap():
     BUILD.mkdir(exist_ok=True)
 
-    venv.create(VENV, with_pip=True)
+    venv.create(VENV, with_pip=True, symlinks=True)
 
     subprocess.run([str(PIP), "install", "-r", str(REQUIREMENTS)], check=True)
 


### PR DESCRIPTION
Per https://github.com/astral-sh/python-build-standalone/issues/381#issuecomment-2616817789 this should stop the build bootsrapping script from crashing when running the build with a standalone Python distribution (which was.. really annoying me).