### PR TITLE
Make the installed pkg-config files relocatable (astral-sh/uv#11028)

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -1116,5 +1116,10 @@ else
     cp -av Tools/scripts/run_tests.py ${ROOT}/out/python/build/
 fi
 
+# Don't hard-code the build-time prefix into the pkg-config files. See
+# the description of `pcfiledir` in `man pkg-config`.
+find ${ROOT}/out/python/install/lib/pkgconfig -name \*.pc -type f -exec \
+    sed ${sed_args} 's|^prefix=/install|prefix=${pcfiledir}/../..|' {} +
+
 mkdir ${ROOT}/out/python/licenses
 cp ${ROOT}/LICENSE.*.txt ${ROOT}/out/python/licenses/

--- a/docs/quirks.rst
+++ b/docs/quirks.rst
@@ -305,7 +305,6 @@ build-time configuration in a handful of files:
   ``lib/python3.10/_sysconfigdata__linux_x86_64-linux-gnu.py``.
 * In a ``Makefile`` under a ``config-*`` directory in the standard library.
   e.g. ``lib/python3.10/config-3.10-x86_64-linux-gnu/Makefile``.
-* In ``pkgconfig`` files. e.g. ``lib/pkgconfig/python3.pc``.
 * In ``python*-config`` files. e.g. ``bin/python3.10-config``.
 * In ``PYTHON.json`` (mostly reflected values from ``_sysconfigdata_*.py``.
 


### PR DESCRIPTION
This ensures that e.g. `PKG_CONFIG_PATH=/wherever/python/lib/pkgconfig pkg-config --cflags` gets you existent paths in /wherever/python instead of nonexistent paths in /install.