### PR TITLE
Adjust python-build-standalone links

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,7 +107,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-${{ env.GIT_REF_NAME }}
             type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-main
-            type=registry,ref=ghcr.io/indygreg/python-build-standalone:${{ matrix.image }}-main
+            type=registry,ref=ghcr.io/astral-sh/python-build-standalone:${{ matrix.image }}-main
           cache-to: |
             type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-${{ env.GIT_REF_NAME }},ignore-error=true
           outputs: |

--- a/Justfile
+++ b/Justfile
@@ -51,8 +51,8 @@ release-set-latest-release tag:
   {
     "version": 1,
     "tag": "{{tag}}",
-    "release_url": "https://github.com/indygreg/python-build-standalone/releases/tag/{{tag}}",
-    "asset_url_prefix": "https://github.com/indygreg/python-build-standalone/releases/download/{{tag}}"
+    "release_url": "https://github.com/astral-sh/python-build-standalone/releases/tag/{{tag}}",
+    "asset_url_prefix": "https://github.com/astral-sh/python-build-standalone/releases/download/{{tag}}"
   }
   EOF
 

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -548,7 +548,7 @@ def python_build_info(
     mips = target_triple.split("-")[0] in {"mips", "mipsel"}
     linux_allowed_system_libraries = LINUX_ALLOW_SYSTEM_LIBRARIES.copy()
     if mips and version == "3.13":
-        # See https://github.com/indygreg/python-build-standalone/issues/410
+        # See https://github.com/astral-sh/python-build-standalone/issues/410
         linux_allowed_system_libraries.add("atomic")
     riscv = target_triple.split("-")[0] in {"riscv64"}
     if riscv:

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -833,7 +833,7 @@ nis:
     # has a wonky history where it was once part of glibc and core system installs
     # but is slowly being phased away from base installations. There are potential
     # workarounds to adding nis support. See discussion in
-    # https://github.com/indygreg/python-build-standalone/issues/51.
+    # https://github.com/astral-sh/python-build-standalone/issues/51.
     - .*
 
   sources:

--- a/docs/quirks.rst
+++ b/docs/quirks.rst
@@ -197,7 +197,7 @@ distributions aren't compatible with
 stipulates that Python and extension modules are linked against a
 dynamic musl. This is what you'll find in Alpine Linux, for example.
 
-See https://github.com/indygreg/python-build-standalone/issues/86 for
+See https://github.com/astral-sh/python-build-standalone/issues/86 for
 a tracking issue to improve the state of musl distributions.
 
 .. _quirk_linux_libx11:
@@ -249,7 +249,7 @@ The static linking of ``libX11`` and other libraries can cause problems when
 loaded into the process. For example, extension modules associated with ``PyQt``
 are known to link against a shared ``libX11.so.6``. If multiple versions of
 ``libX11`` are loaded into the same process, run-time crashes / segfaults can
-occur. See e.g. https://github.com/indygreg/python-build-standalone/issues/95.
+occur. See e.g. https://github.com/astral-sh/python-build-standalone/issues/95.
 
 The conceptual workaround is to not statically link ``libX11`` and similar
 libraries into ``libpython``. However, this requires re-linking a custom
@@ -289,8 +289,8 @@ on ``libcrypt.so.1`` and don't want to upgrade, you can instruct end-users
 to install a ``libxcrypt-compat`` (or comparable) package to provide the
 missing ``libcrypt.so.1``.
 
-See https://github.com/indygreg/python-build-standalone/issues/113 and
-https://github.com/indygreg/python-build-standalone/issues/173 for additional
+See https://github.com/astral-sh/python-build-standalone/issues/113 and
+https://github.com/astral-sh/python-build-standalone/issues/173 for additional
 context on this matter.
 
 .. _quirk_references_to_build_paths:

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -8,14 +8,14 @@ Obtaining Distributions
 =======================
 
 Pre-built distributions are published as releases on GitHub at
-https://github.com/indygreg/python-build-standalone/releases.
+https://github.com/astral-sh/python-build-standalone/releases.
 Simply go to that page and find the latest release along with
 its release notes.
 
 Machines can find the latest release by querying the GitHub releases
 API. Alternatively, a JSON file publishing metadata about the latest
 release can be fetched from
-https://raw.githubusercontent.com/indygreg/python-build-standalone/latest-release/latest-release.json.
+https://raw.githubusercontent.com/astral-sh/python-build-standalone/latest-release/latest-release.json.
 The JSON format is simple and hopefully self-descriptive.
 
 Published distributions vary by their:

--- a/docs/technotes.rst
+++ b/docs/technotes.rst
@@ -120,7 +120,7 @@ versions of Fedora and RHEL.
 Because the ``nis`` extension is perceived to be likely unused functionality,
 we've decided to not build it instead of adding complexity to deal with
 the ``libnsl`` dependency. See further discussion in
-https://github.com/indygreg/python-build-standalone/issues/51.
+https://github.com/astral-sh/python-build-standalone/issues/51.
 
 If ``nis`` functionality is important to you, please file a GitHub issue
 to request it.

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -416,7 +416,7 @@ DOWNLOADS = {
     # IMPORTANT: xz 5.6 has a backdoor. Be extremely cautious before taking any xz
     # upgrade since it isn't clear which versions are safe.
     "xz": {
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/xz-5.2.12.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/xz-5.2.12.tar.gz",
         "size": 2190541,
         "sha256": "61bda930767dcb170a5328a895ec74cab0f5aac4558cdda561c83559db582a13",
         "version": "5.2.12",

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -617,7 +617,7 @@ def validate_python_json(info, extension_modules):
 
 def release_download_statistics(mode="by_asset"):
     with urllib.request.urlopen(
-        "https://api.github.com/repos/indygreg/python-build-standalone/releases"
+        "https://api.github.com/repos/astral-sh/python-build-standalone/releases"
     ) as fh:
         data = json.load(fh)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main_impl() -> Result<()> {
                 Arg::new("organization")
                     .long("org")
                     .action(ArgAction::Set)
-                    .default_value("indygreg")
+                    .default_value("astral-sh")
                     .help("GitHub organization"),
             )
             .arg(
@@ -145,7 +145,7 @@ fn main_impl() -> Result<()> {
                 Arg::new("organization")
                     .long("org")
                     .action(ArgAction::Set)
-                    .default_value("indygreg")
+                    .default_value("astral-sh")
                     .help("GitHub organization"),
             )
             .arg(

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -40,7 +40,7 @@ const RECOGNIZED_TRIPLES: &[&str] = &[
     "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu",
     // Note there's build support for mips* targets but they are not tested
-    // See https://github.com/indygreg/python-build-standalone/issues/412
+    // See https://github.com/astral-sh/python-build-standalone/issues/412
     "mips-unknown-linux-gnu",
     "mipsel-unknown-linux-gnu",
     "mips64el-unknown-linux-gnuabi64",


### PR DESCRIPTION
## Summary

When running locally, I noticed constant redirects in my traffic from `indygreg/python-build-standalone` to `astral-sh/python-build-standalone`. This PR corrects some of the links to avoid the redirects by using the new canonical location.

## Test Plan

Manually verified all adjusted links work as expected.