### PR TITLE
fix: remove release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,3 @@ jobs:
       # Uploading the relevant artifact to the GitHub release.
       - run: just release-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}
         if: ${{ github.event.inputs.dry-run == 'false' }}
-
-      - name: Generate attestations
-        uses: actions/attest-build-provenance@v2
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        with:
-          subject-path: dist/*.tar.@(zst|gz)


### PR DESCRIPTION
See https://github.com/astral-sh/python-build-standalone/actions/runs/13165689836/job/36745165697

This remove release attestations for now until problem with glob resulting in no matches is identified