### PR TITLE
feat: support release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,3 +78,12 @@ jobs:
       # Uploading the relevant artifact to the GitHub release.
       - run: just release-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}
         if: ${{ github.event.inputs.dry-run == 'false' }}
+
+      # We filter by *.tar.@(zst|gz) since actions/attest-build-provenance only supports up to 1024 subjects
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2
+        if: ${{ github.event.inputs.dry-run == 'false' }}
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.tar.zst


### PR DESCRIPTION
## Summary

Reverts https://github.com/astral-sh/python-build-standalone/pull/514

This adds back support for release attestations after asset uploads.

Turns out extended glob is not supported via subject-path given how the action searches the directories and applies the glob, so instead we declare multiple simple globs since subject-path supports that too.

## Test Plan

A full release was tested with about 155 artifacts (had to limit release triplets since free runners have limited resources) which resulted in 76 subjects created due to filtering.

See release here: https://github.com/samypr100/python-build-standalone/releases/tag/20250205

See run here: https://github.com/samypr100/python-build-standalone/actions/runs/13220724442/job/36905418053

See attestations here: https://github.com/samypr100/python-build-standalone/attestations/4870998