### PR TITLE
Update `PYTHON.json` current value for `version` field in documentation

### DIFF
--- a/docs/distributions.rst
+++ b/docs/distributions.rst
@@ -38,7 +38,7 @@ without having to resort to heuristics.
 The file contains a JSON map. This map has the following keys:
 
 version
-   Version number of the file format. Currently ``7``.
+   Version number of the file format. Currently ``8``.
 
 target_triple
    A target triple defining the platform and architecture of the machine


### PR DESCRIPTION
Hi,

Just a minor PR to update `PYTHON.json`'s `version` field value in documentation, following this change

https://github.com/astral-sh/python-build-standalone/commit/0d7e5e018808ce810262627a2f463bb4eb9f7fb0#diff-e777e81ce98aba56bbd99a66c610b273b2869e8c2c048b39eb75c74c83d3b793R1760