### PR TITLE
Fix Windows build job names in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       fail-fast: false
-    name: ${{ matrix.target_triple }} / ${{ matrix.python }} / ${{ matrix.build_option }}
+    name: ${{ matrix.target_triple }} / ${{ matrix.python }} / ${{ matrix.build_options }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<img width="334" alt="Screenshot 2025-02-11 at 10 58 24 PM" src="https://github.com/user-attachments/assets/f63da081-c55d-418f-9f64-3b75b7f13c06" />
<img width="334" alt="Screenshot 2025-02-11 at 10 58 36 PM" src="https://github.com/user-attachments/assets/458bf3b1-b6d2-48cc-9e17-bf1a154b2531" />
