### PR TITLE
Set `enable-experimental-jit=yes-off` on Python 3.13 / Linux

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -427,7 +427,12 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
 
     # Allow users to enable the experimental JIT on 3.13+
     if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]]; then
-        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-experimental-jit=yes-off"
+
+        # The JIT build is failing on macOS and 3.14+ due to compiler errors
+        # Only enable on Linux / 3.13 until that's fixed upstream
+        if [[ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" && "${PYBUILD_PLATFORM}" != "macos" ]]; then
+            CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-experimental-jit=yes-off"
+        fi
 
         if [[ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" ]]; then
             # On 3.13, LLVM 18 is hard-coded into the configure script. Override it to our toolchain

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -428,6 +428,12 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
     # Allow users to enable the experimental JIT on 3.13+
     if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]]; then
         CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-experimental-jit=yes-off"
+
+        if [[ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" ]]; then
+            # On 3.13, LLVM 18 is hard-coded into the configure script. Override it to our toolchain
+            # version.
+            patch -p1 -i "${ROOT}/patch-jit-llvm-19.patch"
+        fi
     fi
 fi
 

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -424,6 +424,11 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
     if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" && -n "${BOLT_CAPABLE}" ]]; then
         CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-bolt"
     fi
+
+    # Allow users to enable the experimental JIT on 3.13+
+    if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]]; then
+        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-experimental-jit=yes-off"
+    fi
 fi
 
 if [ -n "${CPYTHON_LTO}" ]; then

--- a/cpython-unix/patch-jit-llvm-19.patch
+++ b/cpython-unix/patch-jit-llvm-19.patch
@@ -1,0 +1,12 @@
+diff --git a/Tools/jit/_llvm.py b/Tools/jit/_llvm.py
+--- a/Tools/jit/_llvm.py
++++ b/Tools/jit/_llvm.py
+@@ -8,7 +8,7 @@
+ import subprocess
+ import typing
+ 
+-_LLVM_VERSION = 18
++_LLVM_VERSION = 19
+ _LLVM_VERSION_PATTERN = re.compile(rf"version\s+{_LLVM_VERSION}\.\d+\.\d+\S*\s+")
+ 
+ _P = typing.ParamSpec("_P")


### PR DESCRIPTION
See #535 

This builds the JIT, but disables it by default. Users can opt-in to enable it at runtime.

3.14 and macOS support will follow, there are some hiccups there.