### PR TITLE
Enable computed gotos

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -424,6 +424,9 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
     if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" && -n "${BOLT_CAPABLE}" ]]; then
         CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-bolt"
     fi
+
+    # Enable computed-gotos
+    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-computed-gotos"
 fi
 
 if [ -n "${CPYTHON_LTO}" ]; then


### PR DESCRIPTION
These do not appear to be on by default and provide a consistent speed-up. I noticed this while comparing the conda-forge build flags to ours.

```
❯ /Users/zb/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 -m sysconfig | grep GOTO
    HAVE_COMPUTED_GOTOS = "1"
    USE_COMPUTED_GOTOS = "0"
```

It's not clear _why_ they're not enabled. The upstream documentation says they are enabled by default on support compilers and the configure-code is quite straight-forward. Furthermore, we have _problems_ with computed-gotos in PGO / BOLT so they must be available in some capacity? Discussion with the upstream suggests this may be a sysconfig bug — which would mean the following performance improvement isn't true. It's possible there's some other difference I need to dig into.

Using a benchmark derived from #535 on macOS aarch64:

```
❯ hyperfine "/Users/zb/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 bench.py" "./python/install/bin/python bench.py" --min-runs 100
Benchmark 1: /Users/zb/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 bench.py
  Time (mean ± σ):      1.416 s ±  0.025 s    [User: 1.407 s, System: 0.007 s]
  Range (min … max):    1.359 s …  1.473 s    100 runs
 
Benchmark 2: ./python/install/bin/python bench.py
  Time (mean ± σ):      1.309 s ±  0.019 s    [User: 1.301 s, System: 0.007 s]
  Range (min … max):    1.270 s …  1.359 s    100 runs
 
Summary
  ./python/install/bin/python bench.py ran
    1.08 ± 0.02 times faster than /Users/zb/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/bin/python3.13 bench.py
```

I plan to test an artifact with the pyperformance suite on Linux as well