### PR TITLE
Statically link the `python` executable to `libpython` and disable the shared library

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -401,8 +401,8 @@ if [ "${CC}" = "musl-clang" ]; then
         cp "$h" /tools/host/include/
     done
 else
-    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-shared"
-    PYBUILD_SHARED=1
+    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-shared=no"
+    PYBUILD_SHARED=0
 fi
 
 if [ -n "${CPYTHON_DEBUG}" ]; then


### PR DESCRIPTION
As part of investigating #535, we posited that Conda's static linking of the `python` executable was part of the performance difference.

This change gives a 10% performance improvement (geometric mean on pyperformance).