### PR TITLE
Refactor static into the musl build triple

### DIFF
--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -247,7 +247,7 @@ linux:
         minimum-python-version: "3.13"
     run: true
 
-  x86_64-unknown-linux-musl:
+  x86_64-unknown-linux-musl-static:
     arch: x86_64
     libc: musl
     python_versions:
@@ -262,7 +262,7 @@ linux:
       - lto
     run: true
 
-  x86_64_v2-unknown-linux-musl:
+  x86_64_v2-unknown-linux-musl-static:
     arch: x86_64
     arch_variant: v2
     libc: musl
@@ -278,7 +278,7 @@ linux:
       - lto
     run: true
 
-  x86_64_v3-unknown-linux-musl:
+  x86_64_v3-unknown-linux-musl-static:
     arch: x86_64
     arch_variant: v3
     libc: musl
@@ -294,7 +294,7 @@ linux:
       - lto
     run: true
 
-  x86_64_v4-unknown-linux-musl:
+  x86_64_v4-unknown-linux-musl-static:
     arch: x86_64
     arch_variant: v4
     libc: musl

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -381,7 +381,7 @@ CONFIGURE_FLAGS="
     --without-ensurepip
     ${EXTRA_CONFIGURE_FLAGS}"
 
-if [ "${CC}" = "musl-clang" ]; then
+if [ -n "${CPYTHON_STATIC}" ]; then
     CFLAGS="${CFLAGS} -static"
     CPPFLAGS="${CPPFLAGS} -static"
     LDFLAGS="${LDFLAGS} -static"

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -947,7 +947,7 @@ x86_64_v4-unknown-linux-gnu:
   openssl_target: linux-x86_64
   bolt_capable: true
 
-x86_64-unknown-linux-musl:
+x86_64-unknown-linux-musl-static:
   host_platforms:
     - linux64
   pythons_supported:
@@ -990,7 +990,7 @@ x86_64-unknown-linux-musl:
     - zlib
   openssl_target: linux-x86_64
 
-x86_64_v2-unknown-linux-musl:
+x86_64_v2-unknown-linux-musl-static:
   host_platforms:
     - linux64
   pythons_supported:
@@ -1034,7 +1034,7 @@ x86_64_v2-unknown-linux-musl:
     - zlib
   openssl_target: linux-x86_64
 
-x86_64_v3-unknown-linux-musl:
+x86_64_v3-unknown-linux-musl-static:
   host_platforms:
     - linux64
   pythons_supported:
@@ -1078,7 +1078,7 @@ x86_64_v3-unknown-linux-musl:
     - zlib
   openssl_target: linux-x86_64
 
-x86_64_v4-unknown-linux-musl:
+x86_64_v4-unknown-linux-musl-static:
   host_platforms:
     - linux64
   pythons_supported:

--- a/pythonbuild/cpython.py
+++ b/pythonbuild/cpython.py
@@ -466,12 +466,13 @@ def derive_setup_local(
             enabled_extensions[name]["setup_line"] = name.encode("ascii")
             continue
 
-        # musl is static only. Ignore build-mode override.
-        if "musl" in target_triple:
-            section = "static"
-        else:
-            section = info.get("build-mode", "static")
-
+        section = (
+            # If performing a static build, always use static
+            "static"
+            if target_triple.endswith("-static")
+            # Otherwise, use the build mode (falling back to static)
+            else info.get("build-mode", "static")
+        )
         enabled_extensions[name]["build-mode"] = section
 
         # Presumably this means the extension comes from the distribution's


### PR DESCRIPTION
Alternative approach to https://github.com/astral-sh/python-build-standalone/pull/546 using the triple to store static / dynamic instead of the build options.