### PR TITLE
Increase the number of retries on download failure

### DIFF
--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -287,7 +287,7 @@ def download_to_path(url: str, path: pathlib.Path, size: int, sha256: str):
         )
     )
 
-    for attempt in range(5):
+    for attempt in range(8):
         try:
             try:
                 with tmp.open("wb") as fh:


### PR DESCRIPTION
The max retry time before was 16s, here it's bumped to 128s (not counting the previous retry times).

The previous time seems a bit low given the total job runtime and flaked in

- https://github.com/astral-sh/python-build-standalone/actions/runs/13793651007/job/38580117193