### PR TITLE
Declare the `target_cxx` value for all targets

### DIFF
--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -103,7 +103,7 @@ def add_target_env(env, build_platform, target_triple, build_env):
     env["CC"] = settings["target_cc"]
     # We always set CXX, otherwise a build could bypass our toolchain
     # accidentally, e.g., on macOS where `g++` links to the system clang.
-    env["CXX"] = settings.get("target_cxx", settings.get("host_cxx"))
+    env["CXX"] = settings["target_cxx"]
 
     if settings.get("bolt_capable"):
         env["BOLT_CAPABLE"] = "1"

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -25,6 +25,10 @@
 # target_cc
 #    Path to C compiler to use for building binaries targeting the
 #    target architecture.
+
+# target_cxx
+#    Path to C++ compiler to use for building binaries targeting the
+#    target architecture.
 #
 # target_cflags
 #    List of extra compiler flags to use when building for the target.
@@ -69,6 +73,7 @@ aarch64-apple-darwin:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   apple_sdk_platform: macosx
   target_cflags:
     - '-arch'
@@ -114,6 +119,7 @@ aarch64-apple-ios:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'arm64'
@@ -159,6 +165,7 @@ aarch64-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/aarch64-linux-gnu-gcc
+  target_cxx: /usr/bin/aarch64-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -195,6 +202,7 @@ arm64-apple-tvos:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'arm64'
@@ -239,6 +247,7 @@ armv7-unknown-linux-gnueabi:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/arm-linux-gnueabi-gcc
+  target_cxx: /usr/bin/arm-linux-gnueabi-g++
   needs:
     - autoconf
     - bdb
@@ -279,6 +288,7 @@ armv7-unknown-linux-gnueabihf:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/arm-linux-gnueabihf-gcc
+  target_cxx: /usr/bin/arm-linux-gnueabihf-g++
   needs:
     - autoconf
     - bdb
@@ -319,6 +329,7 @@ i686-unknown-linux-gnu:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-m32'
     - '-fvisibility=hidden'
@@ -364,6 +375,7 @@ mips-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/mips-linux-gnu-gcc
+  target_cxx: /usr/bin/mips-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -404,6 +416,7 @@ mipsel-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/mipsel-linux-gnu-gcc
+  target_cxx: /usr/bin/mipsel-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -444,6 +457,7 @@ ppc64le-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/powerpc64le-linux-gnu-gcc
+  target_cxx: /usr/bin/powerpc64le-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -484,6 +498,7 @@ riscv64-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/riscv64-linux-gnu-gcc
+  target_cxx: /usr/bin/riscv64-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -524,6 +539,7 @@ s390x-unknown-linux-gnu:
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/s390x-linux-gnu-gcc
+  target_cxx: /usr/bin/s390x-linux-gnu-g++
   needs:
     - autoconf
     - bdb
@@ -560,6 +576,7 @@ thumb7k-apple-watchos:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'armv7k'
@@ -609,6 +626,7 @@ x86_64-apple-darwin:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'x86_64'
@@ -653,6 +671,7 @@ x86_64-apple-ios:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'x86_64'
@@ -694,6 +713,7 @@ x86_64-apple-tvos:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'x86_64'
@@ -734,6 +754,7 @@ x86_64-apple-watchos:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-arch'
     - 'x86_64'
@@ -778,6 +799,7 @@ x86_64-unknown-linux-gnu:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
@@ -823,6 +845,7 @@ x86_64_v2-unknown-linux-gnu:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v2'
     - '-fvisibility=hidden'
@@ -869,6 +892,7 @@ x86_64_v3-unknown-linux-gnu:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v3'
     - '-fvisibility=hidden'
@@ -915,6 +939,7 @@ x86_64_v4-unknown-linux-gnu:
   host_cc: clang
   host_cxx: clang++
   target_cc: clang
+  target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v4'
     - '-fvisibility=hidden'
@@ -961,6 +986,7 @@ x86_64-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
+  target_cxx: musl-clang++
   target_cflags:
     - '-fvisibility=hidden'
   needs:
@@ -1004,6 +1030,7 @@ x86_64_v2-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
+  target_cxx: musl-clang++
   target_cflags:
     - '-march=x86-64-v2'
     - '-fvisibility=hidden'
@@ -1048,6 +1075,7 @@ x86_64_v3-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
+  target_cxx: musl-clang++
   target_cflags:
     - '-march=x86-64-v3'
     - '-fvisibility=hidden'
@@ -1092,6 +1120,7 @@ x86_64_v4-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
+  target_cxx: musl-clang++
   target_cflags:
     - '-march=x86-64-v4'
     - '-fvisibility=hidden'

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -986,7 +986,7 @@ x86_64-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
-  target_cxx: musl-clang++
+  target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-fvisibility=hidden'
   needs:
@@ -1030,7 +1030,7 @@ x86_64_v2-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
-  target_cxx: musl-clang++
+  target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v2'
     - '-fvisibility=hidden'
@@ -1075,7 +1075,7 @@ x86_64_v3-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
-  target_cxx: musl-clang++
+  target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v3'
     - '-fvisibility=hidden'
@@ -1120,7 +1120,7 @@ x86_64_v4-unknown-linux-musl:
   host_cc: clang
   host_cxx: clang++
   target_cc: musl-clang
-  target_cxx: musl-clang++
+  target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v4'
     - '-fvisibility=hidden'


### PR DESCRIPTION
This value can leak into user builds through sysconfig so it is not appropriate to use the `host_cxx`. See https://github.com/astral-sh/uv/issues/12207

There's not a `musl-clang++` equivalent — so we skip this for those targets.