### PR TITLE
Increase sleep during possible rate limit errors in downloads

### DIFF
--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -307,8 +307,12 @@ def download_to_path(url: str, path: pathlib.Path, size: int, sha256: str):
             print(f"HTTP exception on {url}; retrying: {e}")
             time.sleep(2**attempt)
         except urllib.error.URLError as e:
-            print(f"urllib error on {url}; retrying: {e}")
-            time.sleep(2**attempt)
+            if e.errno in {403, 429}:
+                print(f"possible rate limit error on {url}; retrying: {e}")
+                time.sleep(2 ** (attempt + 2))
+            else:
+                print(f"urllib error on {url}; retrying: {e}")
+                time.sleep(2**attempt)
     else:
         raise Exception(f"download failed after {attempt} retries: {url}")
 

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -310,7 +310,7 @@ def download_to_path(url: str, path: pathlib.Path, size: int, sha256: str):
             print(f"urllib error on {url}; retrying: {e}")
             time.sleep(2**attempt)
     else:
-        raise Exception("download failed after multiple retries: %s" % url)
+        raise Exception(f"download failed after {attempt} retries: {url}")
 
     tmp.rename(path)
     print("successfully downloaded %s" % url)


### PR DESCRIPTION
We're seeing 403s for bzip2 which suggests we're encountering a rate limit. Let's increase the sleep so we aren't spamming the URL.