### PR TITLE
Add option to keep build contexts

### DIFF
--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -249,7 +249,7 @@ def simple_build(
 ):
     archive = download_entry(entry, DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, entry) as build_env:
         if settings.get("needs_toolchain"):
             build_env.install_toolchain(
                 BUILD,
@@ -291,7 +291,7 @@ def build_binutils(client, image, host_platform):
     """Build binutils in the Docker image."""
     archive = download_entry("binutils", DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "binutils") as build_env:
         install_sccache(build_env)
 
         build_env.copy_file(archive)
@@ -332,7 +332,7 @@ def build_musl(client, image, host_platform: str, target_triple: str, build_opti
     musl = "musl-static" if static else "musl"
     musl_archive = download_entry(musl, DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "musl") as build_env:
         build_env.install_toolchain(
             BUILD,
             host_platform,
@@ -362,7 +362,7 @@ def build_libedit(
 ):
     libedit_archive = download_entry("libedit", DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "libedit") as build_env:
         if settings.get("needs_toolchain"):
             build_env.install_toolchain(
                 BUILD,
@@ -397,7 +397,7 @@ def build_tix(
     tk_archive = download_entry("tk", DOWNLOADS_PATH)
     tix_archive = download_entry("tix", DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "tix") as build_env:
         if settings.get("needs_toolchain"):
             build_env.install_toolchain(
                 BUILD,
@@ -444,7 +444,7 @@ def build_cpython_host(
     """Build binutils in the Docker image."""
     archive = download_entry(entry, DOWNLOADS_PATH)
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "cpython-host") as build_env:
         python_version = DOWNLOADS[entry]["version"]
 
         build_env.install_toolchain(
@@ -760,7 +760,7 @@ def build_cpython(
     setup_local_content = setup["setup_local"]
     extra_make_content = setup["make_data"]
 
-    with build_environment(client, image) as build_env:
+    with build_environment(client, image, "cpython") as build_env:
         if settings.get("needs_toolchain"):
             build_env.install_toolchain(
                 BUILD,


### PR DESCRIPTION
i.e., Docker containers and temporary directories.

I have been using a patch like this locally and added an environment variable so we can just have it available. I rebased this quickly and need to double check it works as intended still.