### PR TITLE
Use larger runner for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-24.04-x86_64-16
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We were killed in https://github.com/astral-sh/python-build-standalone/actions/runs/15085967950/job/42408534018
