### PR TITLE
Rework host platform naming

### DIFF
--- a/cpython-unix/Makefile
+++ b/cpython-unix/Makefile
@@ -86,7 +86,7 @@ $(OUTDIR)/$(CLANG_FILENAME):
 $(OUTDIR)/musl-$(MUSL_VERSION)-$(HOST_PLATFORM).tar: $(BASE_TOOLCHAIN_DEPENDS) $(HERE)/build-musl.sh
 	$(RUN_BUILD) --toolchain musl
 
-ifeq ($(HOST_PLATFORM),linux64)
+ifeq ($(HOST_PLATFORM),linux_x86_64)
     TOOLCHAIN_TARGET := $(OUTDIR)/musl-$(MUSL_VERSION)-$(HOST_PLATFORM).tar
 else
     TOOLCHAIN_TARGET :=

--- a/cpython-unix/build-cpython-host.sh
+++ b/cpython-unix/build-cpython-host.sh
@@ -22,7 +22,7 @@ export trailer_m4=${TOOLS_PATH}/host/share/autoconf/autoconf/trailer.m4
 
 # The share/autoconf/autom4te.cfg file also hard-codes some paths. Rewrite
 # those to the real tools path.
-if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
+if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
   sed_args="-i '' -e"
 else
   sed_args="-i"

--- a/cpython-unix/build-main.py
+++ b/cpython-unix/build-main.py
@@ -7,7 +7,6 @@ import argparse
 import multiprocessing
 import os
 import pathlib
-import platform
 import subprocess
 import sys
 
@@ -15,6 +14,8 @@ from pythonbuild.cpython import meets_python_minimum_version
 from pythonbuild.downloads import DOWNLOADS
 from pythonbuild.utils import (
     compress_python_archive,
+    current_host_platform,
+    default_target_triple,
     get_target_settings,
     release_tag_from_git,
     supported_targets,
@@ -28,29 +29,14 @@ TARGETS_CONFIG = SUPPORT / "targets.yml"
 
 
 def main():
-    if sys.platform == "linux":
-        host_platform = "linux64"
-        default_target_triple = "x86_64-unknown-linux-gnu"
-    elif sys.platform == "darwin":
-        host_platform = "macos"
-        machine = platform.machine()
-
-        if machine == "arm64":
-            default_target_triple = "aarch64-apple-darwin"
-        elif machine == "x86_64":
-            default_target_triple = "x86_64-apple-darwin"
-        else:
-            raise Exception("unhandled macOS machine value: %s" % machine)
-    else:
-        print("Unsupported build platform: %s" % sys.platform)
-        return 1
+    host_platform = current_host_platform()
 
     # Note these arguments must be synced with `build.py`
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
         "--target-triple",
-        default=default_target_triple,
+        default=default_target_triple(),
         choices=supported_targets(TARGETS_CONFIG),
         help="Target host triple to build for",
     )

--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -16,7 +16,7 @@ tar -xf ncurses-${NCURSES_VERSION}.tar.gz
 # ncurses version. Our workaround is to build ncurses for the host when
 # cross-compiling then make its `tic` available to the target ncurses
 # build.
-if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != "macos" ]]; then
+if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != macos* ]]; then
   echo "building host ncurses to provide modern tic for cross-compile"
 
   pushd ncurses-${NCURSES_VERSION}
@@ -65,7 +65,7 @@ CONFIGURE_FLAGS="
 # ncurses wants --with-build-cc when cross-compiling. But it insists on CC
 # and this value not being equal, even though using the same binary with
 # different compiler flags is doable!
-if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != "macos" ]]; then
+if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != macos* ]]; then
   CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-build-cc=$(which "${HOST_CC}")"
 fi
 
@@ -91,7 +91,7 @@ fi
 # binary. So we provide a suitable runtime value and then move files at install
 # time.
 
-if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
+if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
   CONFIGURE_FLAGS="${CONFIGURE_FLAGS}
     --datadir=/usr/share
     --sysconfdir=/etc

--- a/cpython-unix/build-tix.sh
+++ b/cpython-unix/build-tix.sh
@@ -28,7 +28,7 @@ if [ "${CC}" = "clang" ]; then
     CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration -Wno-error=incompatible-function-pointer-types"
 fi
 
-if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
+if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
     CFLAGS="${CFLAGS} -I${TOOLS_PATH}/deps/include"
     EXTRA_CONFIGURE_FLAGS="--without-x"
 else

--- a/cpython-unix/build-tk.sh
+++ b/cpython-unix/build-tk.sh
@@ -17,7 +17,7 @@ pushd tk*/unix
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC"
 LDFLAGS="${EXTRA_TARGET_LDFLAGS}"
 
-if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
+if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
     CFLAGS="${CFLAGS} -I${TOOLS_PATH}/deps/include -Wno-availability"
     CFLAGS="${CFLAGS} -Wno-deprecated-declarations -Wno-unknown-attributes -Wno-typedef-redefinition"
     LDFLAGS="-L${TOOLS_PATH}/deps/lib"
@@ -36,7 +36,7 @@ CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
     ${EXTRA_CONFIGURE_FLAGS}
 
 # Remove wish, since we don't need it.
-if [ "${PYBUILD_PLATFORM}" != "macos" ]; then
+if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
     sed -i 's/all: binaries libraries doc/all: libraries/' Makefile
     sed -i 's/install-binaries: $(TK_STUB_LIB_FILE) $(TK_LIB_FILE) ${WISH_EXE}/install-binaries: $(TK_STUB_LIB_FILE) $(TK_LIB_FILE)/' Makefile
 fi

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -61,7 +61,8 @@
 # 11.0+.
 aarch64-apple-darwin:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -111,7 +112,8 @@ aarch64-apple-darwin:
 
 aarch64-apple-ios:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -153,7 +155,7 @@ aarch64-apple-ios:
 
 aarch64-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -194,7 +196,8 @@ aarch64-unknown-linux-gnu:
 
 arm64-apple-tvos:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -235,7 +238,7 @@ arm64-apple-tvos:
 
 armv7-unknown-linux-gnueabi:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -276,7 +279,7 @@ armv7-unknown-linux-gnueabi:
 
 armv7-unknown-linux-gnueabihf:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -317,7 +320,7 @@ armv7-unknown-linux-gnueabihf:
 
 i686-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -363,7 +366,7 @@ i686-unknown-linux-gnu:
 
 mips-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -404,7 +407,7 @@ mips-unknown-linux-gnu:
 
 mipsel-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -445,7 +448,7 @@ mipsel-unknown-linux-gnu:
 
 ppc64le-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -486,7 +489,7 @@ ppc64le-unknown-linux-gnu:
 
 riscv64-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -527,7 +530,7 @@ riscv64-unknown-linux-gnu:
 
 s390x-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -568,7 +571,8 @@ s390x-unknown-linux-gnu:
 
 thumb7k-apple-watchos:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -613,7 +617,8 @@ thumb7k-apple-watchos:
 # machines.
 x86_64-apple-darwin:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -663,7 +668,8 @@ x86_64-apple-darwin:
 
 x86_64-apple-ios:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -705,7 +711,8 @@ x86_64-apple-ios:
 
 x86_64-apple-tvos:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -746,7 +753,8 @@ x86_64-apple-tvos:
 
 x86_64-apple-watchos:
   host_platforms:
-    - macos
+    - macos_arm64
+    - macos_x86_64
   pythons_supported:
     - '3.9'
   needs_toolchain: true
@@ -787,7 +795,7 @@ x86_64-apple-watchos:
 
 x86_64-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -833,7 +841,7 @@ x86_64-unknown-linux-gnu:
 
 x86_64_v2-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -880,7 +888,7 @@ x86_64_v2-unknown-linux-gnu:
 
 x86_64_v3-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -927,7 +935,7 @@ x86_64_v3-unknown-linux-gnu:
 
 x86_64_v4-unknown-linux-gnu:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -974,7 +982,7 @@ x86_64_v4-unknown-linux-gnu:
 
 x86_64-unknown-linux-musl:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -1018,7 +1026,7 @@ x86_64-unknown-linux-musl:
 
 x86_64_v2-unknown-linux-musl:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -1063,7 +1071,7 @@ x86_64_v2-unknown-linux-musl:
 
 x86_64_v3-unknown-linux-musl:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'
@@ -1108,7 +1116,7 @@ x86_64_v3-unknown-linux-musl:
 
 x86_64_v4-unknown-linux-musl:
   host_platforms:
-    - linux64
+    - linux_x86_64
   pythons_supported:
     - '3.9'
     - '3.10'


### PR DESCRIPTION
"host platform" is this concept I invented very early in the project to encode the build machine os and architecture. I chose "linux64" to represent Linux x86-64. And for reasons I can't recall, I never qualified the macOS architecture into the name like I did for Linux.

This commit refactors the string so that it is consistently `os_arch`. `linux64` becomes `linux_x86_64`. `macos` becomes `macos_x86_64` and `macos_arm64`.

I'm doing this cleanup in service of native ARM Linux builds. `linux64` is ambiguous. And macOS not behaving the same was always wonky. Let's impose some consistency instead of layering hacks upon hacks.