### PR TITLE
Use `gh release` instead of someone's release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - run: just release-dry-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}
         if: ${{ github.event.inputs.dry-run == 'true' }}
 
-      # Create the release itself.
+      # Set our identity for git operations (on the latest-release branch).
       - name: Configure Git identity
         if: ${{ github.event.inputs.dry-run == 'false' }}
         run: |
@@ -66,14 +66,7 @@ jobs:
       # Create a GitHub release.
       - name: Create GitHub Release
         if: ${{ github.event.inputs.dry-run == 'false' }}
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ github.event.inputs.tag }}
-          name: ${{ github.event.inputs.tag }}
-          prerelease: true
-          body: TBD
-          allowUpdates: true
-          updateOnlyUnreleased: true
+        run: just release-create ${{ github.events.input.tag }}
 
       # Uploading the relevant artifact to the GitHub release.
       - run: just release-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}

--- a/Justfile
+++ b/Justfile
@@ -67,6 +67,28 @@ release-set-latest-release tag:
     echo "No changes to commit."
   fi
 
+# Create a GitHub release object, or reuse an existing prerelease.
+release-create tag:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  prerelease_exists=$(gh release view {{tag}} --json isPrerelease -t '{{{{.isPrerelease}}' 2>&1 || true)
+  case "$prerelease_exists" in
+    true)
+      echo "note: updating existing prerelease {{tag}}"
+      ;;
+    false)
+      echo "error: release {{tag}} already exists"
+      exit 1
+      ;;
+    "release not found")
+      gh release create {{tag}} --prerelease --notes TBD --verify-tag
+      ;;
+    *)
+      echo "error: unexpected gh cli output: $prerelease_exists"
+      exit 1
+      ;;
+  esac
+
 # Perform the release job. Assumes that the GitHub Release has been created.
 release-run token commit tag:
   #!/bin/bash


### PR DESCRIPTION
The upstream action times out because it requests every release (without pagination), and there's no real need to use a third-party action for this when the `gh` command does a perfectly fine job too.