### PR TITLE
Add loongarch64-linux support

### DIFF
--- a/cpython-unix/base.Dockerfile
+++ b/cpython-unix/base.Dockerfile
@@ -1,6 +1,6 @@
 # Debian Jessie.
 FROM debian@sha256:32ad5050caffb2c7e969dac873bce2c370015c2256ff984b70c1c08b3a2816a0
-MAINTAINER Gregory Szorc <gregory.szorc@gmail.com>
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \

--- a/cpython-unix/base.debian9.Dockerfile
+++ b/cpython-unix/base.debian9.Dockerfile
@@ -1,6 +1,6 @@
 # Debian Stretch.
 FROM debian@sha256:c5c5200ff1e9c73ffbf188b4a67eb1c91531b644856b4aefe86a58d2f0cb05be
-MAINTAINER Gregory Szorc <gregory.szorc@gmail.com>
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -69,6 +69,15 @@ if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
     fi
 fi
 
+# configure doesn't support cross-compiling on LoongArch. Teach it.
+if [ "${PYBUILD_PLATFORM}" != "macos" ]; then
+    case "${PYTHON_MAJMIN_VERSION}" in
+        3.9|3.10|3.11)
+            patch -p1 -i ${ROOT}/patch-configure-add-loongarch-triplet.patch
+            ;;
+    esac
+fi
+
 # disable readelf check when cross-compiling on older Python versions
 if [ -n "${CROSS_COMPILING}" ]; then
     if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
@@ -1096,6 +1105,9 @@ armv7-unknown-linux-gnueabi)
     ;;
 armv7-unknown-linux-gnueabihf)
     PYTHON_ARCH="arm-linux-gnueabihf"
+    ;;
+loongarch64-unknown-linux-gnu)
+    PYTHON_ARCH="loongarch64-linux-gnu"
     ;;
 mips-unknown-linux-gnu)
     PYTHON_ARCH="mips-linux-gnu"

--- a/cpython-unix/build-libX11.sh
+++ b/cpython-unix/build-libX11.sh
@@ -54,6 +54,9 @@ if [ -n "${CROSS_COMPILING}" ]; then
     armv7-unknown-linux-gnueabihf)
       EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
       ;;
+    loongarch64-unknown-linux-gnu)
+      EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
+      ;;
     mips-unknown-linux-gnu)
       EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
       ;;
@@ -76,6 +79,9 @@ if [ -n "${CROSS_COMPILING}" ]; then
       EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
       ;;
     aarch64-unknown-linux-musl)
+      EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
+      ;;
+    loongarch64-unknown-linux-musl)
       EXTRA_FLAGS="${EXTRA_FLAGS} --enable-malloc0returnsnull"
       ;;
     mips-unknown-linux-musl)

--- a/cpython-unix/build-libxcb.sh
+++ b/cpython-unix/build-libxcb.sh
@@ -13,6 +13,12 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
 tar -xf libxcb-${LIBXCB_VERSION}.tar.gz
 pushd libxcb-${LIBXCB_VERSION}
 
+if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
+    rm -f build-aux/config.guess build-aux/config.sub
+    curl -sSL -o build-aux/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess'
+    curl -sSL -o build-aux/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub'
+fi
+
 if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi

--- a/cpython-unix/build-main.py
+++ b/cpython-unix/build-main.py
@@ -95,6 +95,7 @@ def main():
             "toolchain-image-build",
             "toolchain-image-build.cross",
             "toolchain-image-build.cross-riscv64",
+            "toolchain-image-build.cross-loongarch64",
             "toolchain-image-build.debian9",
             "toolchain-image-gcc",
             "toolchain-image-xcb",

--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -109,6 +109,8 @@ else
   "
 fi
 
+mkdir -p ${ROOT}/out/usr/lib
+
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure ${CONFIGURE_FLAGS}
 make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xorgproto.sh
+++ b/cpython-unix/build-xorgproto.sh
@@ -15,6 +15,12 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf xorgproto-${XORGPROTO_VERSION}.tar.gz
 pushd xorgproto-${XORGPROTO_VERSION}
 
+if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
+    rm -f config.guess.sub config.sub
+    curl -sSL -o config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess'
+    curl -sSL -o config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub'
+fi
+
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
     --build=${BUILD_TRIPLE} \
     --host=${TARGET_TRIPLE} \

--- a/cpython-unix/build.Dockerfile
+++ b/cpython-unix/build.Dockerfile
@@ -9,6 +9,8 @@
 # Various other build tools are needed for various building.
 RUN ulimit -n 10000 && apt-get install \
     bzip2 \
+    ca-certificates \
+    curl \
     file \
     libc6-dev \
     libffi-dev \

--- a/cpython-unix/build.cross-loongarch64.Dockerfile
+++ b/cpython-unix/build.cross-loongarch64.Dockerfile
@@ -1,0 +1,64 @@
+# Debian Trixie.
+FROM debian@sha256:5e64db7e29879fbb479ab2c6324656c9c0e489423e4885ed7e2f22c5b58a7a9b
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
+
+RUN groupadd -g 1000 build && \
+    useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \
+    mkdir /tools && \
+    chown -R build:build /build /tools
+
+ENV HOME=/build \
+    SHELL=/bin/bash \
+    USER=build \
+    LOGNAME=build \
+    HOSTNAME=builder \
+    DEBIAN_FRONTEND=noninteractive
+
+CMD ["/bin/bash", "--login"]
+WORKDIR '/build'
+
+RUN for s in debian_trixie debian_trixie-updates; do \
+      echo "deb http://snapshot.debian.org/archive/${s%_*}/20240812T212427Z/ ${s#*_} main"; \
+    done > /etc/apt/sources.list && \
+    for s in debian-security_trixie-security/updates; do \
+      echo "deb http://snapshot.debian.org/archive/${s%_*}/20240813T064849Z/ ${s#*_} main"; \
+    done >> /etc/apt/sources.list && \
+    ( echo 'quiet "true";'; \
+      echo 'APT::Get::Assume-Yes "true";'; \
+      echo 'APT::Install-Recommends "false";'; \
+      echo 'Acquire::Check-Valid-Until "false";'; \
+      echo 'Acquire::Retries "5";'; \
+    ) > /etc/apt/apt.conf.d/99cpython-portable && \
+    rm -f /etc/apt/sources.list.d/*
+
+RUN apt-get update
+
+# Host building.
+RUN apt-get install \
+    bzip2 \
+    ca-certificates \
+    curl \
+    gcc \
+    g++ \
+    libc6-dev \
+    libffi-dev \
+    make \
+    patch \
+    perl \
+    pkg-config \
+    tar \
+    xz-utils \
+    unzip \
+    zip \
+    zlib1g-dev
+
+RUN apt-get install \
+    gcc-loongarch64-linux-gnu \
+    libc6-dev-loong64-cross
+
+RUN cd /tmp && \
+    curl -LO https://snapshot.debian.org/archive/debian-ports/20240812T192057Z/pool-loong64/main/libx/libxcrypt/libcrypt-dev_4.4.36-4_loong64.deb && \
+    curl -LO https://snapshot.debian.org/archive/debian-ports/20240812T192057Z/pool-loong64/main/libx/libxcrypt/libcrypt1_4.4.36-4_loong64.deb && \
+    dpkg -x libcrypt-dev_4.4.36-4_loong64.deb / && \
+    dpkg -x libcrypt1_4.4.36-4_loong64.deb / && \
+    rm -f /tmp/*.deb

--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -1,6 +1,6 @@
 # Debian Buster.
 FROM debian@sha256:2a0c1b9175adf759420fe0fbd7f5b449038319171eb76554bb76cbe172b62b42
-MAINTAINER Gregory Szorc <gregory.szorc@gmail.com>
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \

--- a/cpython-unix/build.cross.Dockerfile
+++ b/cpython-unix/build.cross.Dockerfile
@@ -1,6 +1,6 @@
 # Debian Stretch.
 FROM debian@sha256:cebe6e1c30384958d471467e231f740e8f0fd92cbfd2a435a186e9bada3aee1c
-MAINTAINER Gregory Szorc <gregory.szorc@gmail.com>
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -261,6 +261,7 @@ _decimal:
     - define: CONFIG_64=1
       targets:
         - aarch64-.*
+        - loongarch64-unknown-linux.*
         - ppc64le-unknown-linux.*
         - riscv64-unknown-linux.*
         - s390x-unknown-linux-.*

--- a/cpython-unix/patch-configure-add-loongarch-triplet.patch
+++ b/cpython-unix/patch-configure-add-loongarch-triplet.patch
@@ -1,0 +1,50 @@
+diff --git a/configure b/configure
+index b7be60e..d799415 100755
+--- a/configure
++++ b/configure
+@@ -5261,6 +5261,20 @@ cat >> conftest.c <<EOF
+         hppa-linux-gnu
+ # elif defined(__ia64__)
+         ia64-linux-gnu
++# elif defined(__loongarch__)
++#  if defined(__loongarch_lp64)
++#   if defined(__loongarch_soft_float)
++        loongarch64-linux-gnusf
++#   elif defined(__loongarch_single_float)
++        loongarch64-linux-gnuf32
++#   elif defined(__loongarch_double_float)
++        loongarch64-linux-gnu
++#   else
++#    error unknown platform triplet
++#   endif
++#  else
++#   error unknown platform triplet
++#  endif
+ # elif defined(__m68k__) && !defined(__mcoldfire__)
+         m68k-linux-gnu
+ # elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)
+diff --git a/configure.ac b/configure.ac
+index aa515da..b5bad6e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -779,6 +779,20 @@ cat >> conftest.c <<EOF
+         hppa-linux-gnu
+ # elif defined(__ia64__)
+         ia64-linux-gnu
++# elif defined(__loongarch__)
++#  if defined(__loongarch_lp64)
++#   if defined(__loongarch_soft_float)
++        loongarch64-linux-gnusf
++#   elif defined(__loongarch_single_float)
++        loongarch64-linux-gnuf32
++#   elif defined(__loongarch_double_float)
++        loongarch64-linux-gnu
++#   else
++#    error unknown platform triplet
++#   endif
++#  else
++#   error unknown platform triplet
++#  endif
+ # elif defined(__m68k__) && !defined(__mcoldfire__)
+         m68k-linux-gnu
+ # elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -332,6 +332,47 @@ armv7-unknown-linux-gnueabihf:
     - zstd
   openssl_target: linux-armv4
 
+loongarch64-unknown-linux-gnu:
+  host_platforms:
+    - linux_x86_64
+  pythons_supported:
+    - '3.9'
+    - '3.10'
+    - '3.11'
+    - '3.12'
+    - '3.13'
+    - '3.14'
+  docker_image_suffix: .cross-loongarch64
+  host_cc: /usr/bin/x86_64-linux-gnu-gcc
+  host_cxx: /usr/bin/x86_64-linux-gnu-g++
+  target_cc: /usr/bin/loongarch64-linux-gnu-gcc
+  target_cxx: /usr/bin/loongarch64-linux-gnu-g++
+  needs:
+    - autoconf
+    - bdb
+    - binutils
+    - bzip2
+    - expat
+    - libedit
+    - libffi
+    - libX11
+    - libXau
+    - libxcb
+    - m4
+    - mpdecimal
+    - ncurses
+    - openssl-3.0
+    - patchelf
+    - sqlite
+    - tcl
+    - tk
+    - uuid
+    - xorgproto
+    - xz
+    - zlib
+    - zstd
+  openssl_target: linux64-loongarch64
+
 mips-unknown-linux-gnu:
   host_platforms:
     - linux_x86_64

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -39,6 +39,7 @@ As are various other targets::
     $ ./build-linux.py --target aarch64-unknown-linux-gnu
     $ ./build-linux.py --target armv7-unknown-linux-gnueabi
     $ ./build-linux.py --target armv7-unknown-linux-gnueabihf
+    $ ./build-linux.py --target loongarch64-unknown-linux-gnu
     $ ./build-linux.py --target mips-unknown-linux-gnu
     $ ./build-linux.py --target mipsel-unknown-linux-gnu
     $ ./build-linux.py --target ppc64le-unknown-linux-gnu


### PR DESCRIPTION
- https://github.com/astral-sh/python-build-standalone/issues/204

Add support for loongarch64 linux gnu target.

No automated builds; manual execution of `./build-linux.py --target loongarch64-unknown-linux-gnu`.

