### PR TITLE
use raw string literal for regex

### DIFF
--- a/pythonbuild/cpython.py
+++ b/pythonbuild/cpython.py
@@ -672,7 +672,7 @@ def derive_setup_local(
     }
 
 
-RE_INITTAB_ENTRY = re.compile('\{"([^"]+)", ([^\}]+)\},')
+RE_INITTAB_ENTRY = re.compile(r'\{"([^"]+)", ([^\}]+)\},')
 
 
 def parse_config_c(s: str):


### PR DESCRIPTION
Uses a raw string literal for the regex to avoid
```
python-build-standalone/pythonbuild/cpython.py:675: SyntaxWarning: invalid escape sequence '\{'
  RE_INITTAB_ENTRY = re.compile('\{"([^"]+)", ([^\}]+)\},')
```