### PR TITLE
Drop `.sha256` files from releases

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -505,14 +505,6 @@ pub async fn command_upload_release_distributions(args: &ArgMatches) -> Result<(
                 file_data,
                 dry_run,
             ));
-            fs.push(upload_release_artifact(
-                &raw_client,
-                token.clone(),
-                &release,
-                format!("{}.sha256", dest),
-                Bytes::copy_from_slice(format!("{}\n", digest).as_bytes()),
-                dry_run,
-            ));
         }
 
         let mut buffered = futures::stream::iter(fs).buffer_unordered(16);


### PR DESCRIPTION
GitHub has started enforcing a 1000 file limit, which breaks us.

I first encountered it in CI during the release: https://github.com/astral-sh/python-build-standalone/actions/runs/16156480423

Then got to an actual error message via the CLI:

```
❯ gh release upload 20250708 dist/cpython-3.14.0b4-riscv64-unknown-linux-gnu-freethreaded+lto-20250708T1536.tar.zst
HTTP 422: Validation Failed (https://uploads.github.com/repos/astral-sh/python-build-standalone/releases/230978017/assets?label=&name=cpython-3.14.0b4-riscv64-unknown-linux-gnu-freethreaded%2Blto-20250708T1536.tar.zst)
file_count limited to 1000 assets per release
```

You can see they documented a limit recently:

https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas

https://web.archive.org/web/20250629152715/https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases