### PR TITLE
Skip sqlite3 geopoly test on Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -249,6 +249,19 @@ jobs:
 
           ./build-linux.py --target-triple ${{ matrix.target_triple }} --python cpython-${{ matrix.python }} --options ${{ matrix.build_options }}
 
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          subject-path: dist/*
+
+      - name: Upload Distribution
+        if: ${{ ! matrix.dry-run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
+          path: dist/*
+
       - name: Validate Distribution
         if: ${{ ! matrix.dry-run }}
         run: |
@@ -266,19 +279,6 @@ jobs:
           fi
 
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
-
-      - name: Generate attestations
-        uses: actions/attest-build-provenance@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          subject-path: dist/*
-
-      - name: Upload Distribution
-        if: ${{ ! matrix.dry-run }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
-          path: dist/*
 
   build-1:
     needs:
@@ -349,6 +349,19 @@ jobs:
 
           ./build-linux.py --target-triple ${{ matrix.target_triple }} --python cpython-${{ matrix.python }} --options ${{ matrix.build_options }}
 
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          subject-path: dist/*
+
+      - name: Upload Distribution
+        if: ${{ ! matrix.dry-run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
+          path: dist/*
+
       - name: Validate Distribution
         if: ${{ ! matrix.dry-run }}
         run: |
@@ -366,16 +379,3 @@ jobs:
           fi
 
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
-
-      - name: Generate attestations
-        uses: actions/attest-build-provenance@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          subject-path: dist/*
-
-      - name: Upload Distribution
-        if: ${{ ! matrix.dry-run }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
-          path: dist/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -146,12 +146,6 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\${{ matrix.vcvars }}"
           py.exe -3.12 build-windows.py --python cpython-${{ matrix.python }} --sh c:\cygwin\bin\sh.exe --options ${{ matrix.build_options }}
 
-      - name: Validate Distribution
-        if: ${{ ! matrix.dry-run }}
-        run: |
-          $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
-          .\pythonbuild.exe validate-distribution --run $Dists
-
       - name: Generate attestations
         uses: actions/attest-build-provenance@v2
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -163,3 +157,9 @@ jobs:
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.vcvars }}-${{ matrix.build_options }}
           path: dist/*
+
+      - name: Validate Distribution
+        if: ${{ ! matrix.dry-run }}
+        run: |
+          $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
+          .\pythonbuild.exe validate-distribution --run $Dists

--- a/src/verify_distribution.py
+++ b/src/verify_distribution.py
@@ -128,8 +128,12 @@ class TestPythonInterpreter(unittest.TestCase):
         cursor.execute("CREATE VIRTUAL TABLE fts3 USING fts3(sender, title, body);")
         cursor.execute("CREATE VIRTUAL TABLE fts4 USING fts4(sender, title, body);")
         cursor.execute("CREATE VIRTUAL TABLE fts5 USING fts5(sender, title, body);")
-        cursor.execute("CREATE VIRTUAL TABLE geopoly USING geopoly();")
         cursor.execute("CREATE VIRTUAL TABLE rtree USING rtree(id, minX, maxX);")
+        if os.name != "nt":
+            # TODO(geofft): not sure why this isn't present in the prebuilt
+            # sqlite3 Windows library from CPython upstream, it seems weird to
+            # be inconsistent across platforms, but that's the status quo
+            cursor.execute("CREATE VIRTUAL TABLE geopoly USING geopoly();")
         conn.close()
 
     def test_ssl(self):


### PR DESCRIPTION
Also reorder the CI validate/upload steps so that if this goes wrong again we can still cut a release without rebuilding.