### PR TITLE
Run dependabot monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: "pip"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "monthly"
   groups:
     python:
       patterns:
@@ -11,7 +11,7 @@ updates:
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "monthly"
   groups:
     rust:
       patterns:


### PR DESCRIPTION
The CI is expensive and there is ~no benefit to end users from a faster update cadence
