### PR TITLE
Use a larger runner again for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     name: Release
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
 
     permissions:
       contents: write


### PR DESCRIPTION
We need more disk space.

Partially reverts https://github.com/astral-sh/python-build-standalone/commit/a376f32981a4e690963fe29a6ae31203afb440ae though I'm using an 8-core instead of 16-core runner and Depot instead of GitHub.
