### PR TITLE
Try a theory in CI: -fvisibility=hidden doesn't do anything

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -315,10 +315,6 @@ fi
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -I${TOOLS_PATH}/deps/include -I${TOOLS_PATH}/deps/include/ncursesw"
 LDFLAGS="${EXTRA_TARGET_LDFLAGS} -L${TOOLS_PATH}/deps/lib"
 
-# Some target configurations use `-fvisibility=hidden`. Python's configure handles
-# symbol visibility properly itself. So let it do its thing.
-CFLAGS=${CFLAGS//-fvisibility=hidden/}
-
 # But some symbols from some dependency libraries are still non-hidden for some
 # reason. We force the linker to do our bidding.
 if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -90,7 +90,6 @@ aarch64-apple-darwin:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'arm64'
@@ -137,7 +136,6 @@ aarch64-apple-ios:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'arm64'
@@ -173,7 +171,6 @@ aarch64-unknown-linux-gnu:
   target_cc: clang
   target_cxx: clang++
   target_cflags:
-    - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
   needs:
@@ -234,7 +231,6 @@ arm64-apple-tvos:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'arm64'
@@ -571,7 +567,6 @@ thumb7k-apple-watchos:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'armv7k'
@@ -623,7 +618,6 @@ x86_64-apple-darwin:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'x86_64'
@@ -670,7 +664,6 @@ x86_64-apple-ios:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'x86_64'
@@ -714,7 +707,6 @@ x86_64-apple-tvos:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'x86_64'
@@ -757,7 +749,6 @@ x86_64-apple-watchos:
     # to work with the macOS SDKs out of the box. We work around
     # this by undoing the -Werror=undef-prefix in that commit.
     - '-Wno-undef-prefix'
-    - '-fvisibility=hidden'
   target_ldflags:
     - '-arch'
     - 'x86_64'
@@ -790,7 +781,6 @@ x86_64-unknown-linux-gnu:
   target_cc: clang
   target_cxx: clang++
   target_cflags:
-    - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
   needs:
@@ -838,7 +828,6 @@ x86_64_v2-unknown-linux-gnu:
   target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v2'
-    - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
   needs:
@@ -886,7 +875,6 @@ x86_64_v3-unknown-linux-gnu:
   target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v3'
-    - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
   needs:
@@ -934,7 +922,6 @@ x86_64_v4-unknown-linux-gnu:
   target_cxx: clang++
   target_cflags:
     - '-march=x86-64-v4'
-    - '-fvisibility=hidden'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
   needs:
@@ -980,8 +967,6 @@ x86_64-unknown-linux-musl:
   host_cxx: clang++
   target_cc: musl-clang
   target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
-  target_cflags:
-    - '-fvisibility=hidden'
   needs:
     - autoconf
     - bdb
@@ -1027,7 +1012,6 @@ x86_64_v2-unknown-linux-musl:
   target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v2'
-    - '-fvisibility=hidden'
   needs:
     - autoconf
     - bdb
@@ -1073,7 +1057,6 @@ x86_64_v3-unknown-linux-musl:
   target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v3'
-    - '-fvisibility=hidden'
   needs:
     - autoconf
     - bdb
@@ -1119,7 +1102,6 @@ x86_64_v4-unknown-linux-musl:
   target_cxx: clang++  # TODO: Explore a musl-clang++ shim?
   target_cflags:
     - '-march=x86-64-v4'
-    - '-fvisibility=hidden'
   needs:
     - autoconf
     - bdb


### PR DESCRIPTION
What matters is -Wl,--exclude-libs=ALL for all of our shared objects, of which in the current commit there is only python and libpython, which already uses it.