### PR TITLE
chore(ci): drop ref-pin exceptions in zizmor

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,6 +2,4 @@ rules:
   unpinned-uses:
     config:
       policies:
-        actions/*: ref-pin
-        astral-sh/*: ref-pin
         "*": hash-pin


### PR DESCRIPTION
Follows #763.

This essentially makes zizmor's policy as strict as the one we've enabled on GH.