### PR TITLE
Reproducible artifact hashes for base builder images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,6 +97,8 @@ jobs:
       - name: Build Image
         id: build-image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        env:
+          SOURCE_DATE_EPOCH: 0
         with:
           context: .
           file: build/${{ matrix.name }}.Dockerfile
@@ -118,6 +120,7 @@ jobs:
         run: |
           echo ${STEPS_BUILD_IMAGE_OUTPUTS_IMAGEID} > build/image-${MATRIX_NAME}.linux_${MATRIX_ARCH}
           zstd -v -T0 -6 --rm build/image-*.tar
+          touch -t 197001010000 build/image-*
         env:
           STEPS_BUILD_IMAGE_OUTPUTS_IMAGEID: ${{ steps.build-image.outputs.imageid }}
           MATRIX_NAME: ${{ matrix.name }}
@@ -128,6 +131,7 @@ jobs:
         with:
           name: image-${{ matrix.name }}-linux_${{ matrix.arch }}
           path: build/image-*
+          compression-level: '0'
 
   generate-matrix:
     name: Generate build matrix


### PR DESCRIPTION
I was looking at the build pipeline for the distributions, and was surprised to find the builder image artifacts having different SHA256 hashes across runs. 

e.g. compare the output of the "Upload Docker Image" step of two jobs:

https://github.com/chowder/python-build-standalone/actions/runs/17012490960/job/48230404008
https://github.com/chowder/python-build-standalone/actions/runs/17012490960/job/48230532790

For the same image: 

```
SHA256 digest of uploaded artifact zip is d47e11cc1c0e648bed6ec64a3613fa166c317981d252085c241c05745604973b
Finalizing artifact upload
Artifact image-build-linux_x86_64.zip successfully finalized. Artifact ID 3780654566
Artifact image-build-linux_x86_64 has been successfully uploaded! Final size is 80890477 bytes. Artifact ID is 3780654566
```
```
SHA256 digest of uploaded artifact zip is 3341d64b1d7efb680db3e4d62ae3dab9bf24e22e384f585aaf3a5b551aee5e7b
Finalizing artifact upload
Artifact image-build-linux_x86_64.zip successfully finalized. Artifact ID 3780667100
Artifact image-build-linux_x86_64 has been successfully uploaded! Final size is 80890477 bytes. Artifact ID is 3780667100
```

Turns out this is because the `upload-artifact` step applies a layer of compression to the specified files, but doesn't reset/zero out the mtime, thus making these artifacts non-reproducible. 

Given that the docker images are already compressed [in a prior step](https://github.com/astral-sh/python-build-standalone/blob/main/.github/workflows/linux.yml#L117-L120): 

```yaml
      - name: Compress Image
        run: |
          echo ${STEPS_BUILD_IMAGE_OUTPUTS_IMAGEID} > build/image-${MATRIX_NAME}.linux_${MATRIX_ARCH}
          zstd -v -T0 -6 --rm build/image-*.tar
``` 

We can skip the compression in the `upload-artifact` step, and get reproducible artifacts each time. 

#### Test Evidence

See these two runs that include the proposed changes: 

https://github.com/chowder/python-build-standalone/actions/runs/17012517183/job/48230459046
https://github.com/chowder/python-build-standalone/actions/runs/17012517183/job/48230772691

Both generate the same digest: 

```
Finished uploading artifact content to blob storage!
SHA256 digest of uploaded artifact zip is c73f01690d74c103f92bd8113ff158e8b8d2d4de19dca96d36b3d6fbc688fe16
Finalizing artifact upload
Artifact image-build-linux_x86_64.zip successfully finalized. Artifact ID 3780661038
Artifact image-build-linux_x86_64 has been successfully uploaded! Final size is 81208314 bytes. Artifact ID is 3780661038
```

```
SHA256 digest of uploaded artifact zip is c73f01690d74c103f92bd8113ff158e8b8d2d4de19dca96d36b3d6fbc688fe16
Finalizing artifact upload
Artifact image-build-linux_x86_64.zip successfully finalized. Artifact ID 3780693018
Artifact image-build-linux_x86_64 has been successfully uploaded! Final size is 81208314 bytes. Artifact ID is 3780693018
```