### PR TITLE
Refactor Setup.local define logic to avoid supplemental makefile

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -54,8 +54,6 @@ SETUPTOOLS_WHEEL="${ROOT}/setuptools-${SETUPTOOLS_VERSION}-py3-none-any.whl"
 cat Setup.local
 mv Setup.local Python-${PYTHON_VERSION}/Modules/Setup.local
 
-cat Makefile.extra
-
 pushd Python-${PYTHON_VERSION}
 
 # configure doesn't support cross-compiling on Apple. Teach it.
@@ -648,9 +646,6 @@ fi
 
 CFLAGS=$CFLAGS CPPFLAGS=$CFLAGS CFLAGS_JIT=$CFLAGS_JIT LDFLAGS=$LDFLAGS \
     ./configure ${CONFIGURE_FLAGS}
-
-# Supplement produced Makefile with our modifications.
-cat ../Makefile.extra >> Makefile
 
 make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} sharedinstall DESTDIR=${ROOT}/out/python

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -728,7 +728,6 @@ def build_cpython(
 
     enabled_extensions = setup["extensions"]
     setup_local_content = setup["setup_local"]
-    extra_make_content = setup["make_data"]
 
     with build_environment(client, image) as build_env:
         if settings.get("needs_toolchain"):
@@ -780,13 +779,6 @@ def build_cpython(
             fh.flush()
 
             build_env.copy_file(fh.name, dest_name="Setup.local")
-
-        with tempfile.NamedTemporaryFile("wb") as fh:
-            os.chmod(fh.name, 0o644)
-            fh.write(extra_make_content)
-            fh.flush()
-
-            build_env.copy_file(fh.name, dest_name="Makefile.extra")
 
         env = {
             "PIP_VERSION": DOWNLOADS["pip"]["version"],

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -546,7 +546,7 @@ _sqlite3:
     - define: SQLITE_OMIT_LOAD_EXTENSION=1
       targets:
         - .*-ios
-    - define: "MODULE_NAME=\\\"sqlite3\\\""
+    - define: "MODULE_NAME='\"sqlite3\"'"
       maximum-python-version: "3.9"
   links:
     - sqlite3


### PR DESCRIPTION
Putting all defines, particularly -Dfoo=bar values, into a separate line in Setup.local makes is so that no supplemental Makefile is needed to work around the makesetup logic.