### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -460,7 +460,7 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
     if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]]; then
 
         # Do not enable on x86-64 macOS because the JIT requires macOS 11+ and we are currently
-        # using 10.15 as a miniumum version.
+        # using 10.15 as a minimum version.
         # Do not enable when free-threading, because they're not compatible yet.
         if [[ ! ( "${TARGET_TRIPLE}" == "x86_64-apple-darwin" || -n "${CPYTHON_FREETHREADED}" ) ]]; then
             CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --enable-experimental-jit=yes-off"

--- a/cpython-unix/build-libffi.sh
+++ b/cpython-unix/build-libffi.sh
@@ -225,7 +225,7 @@ index 60cfa50..6a9a561 100644
  	BTI_C
 -	/* Sign the lr with x1 since that is where it will be stored */
 +	PAC_CFI_WINDOW_SAVE
-+	/* Sign the lr with x1 since that is the CFA which is the modifer used in auth instructions */
++	/* Sign the lr with x1 since that is the CFA which is the modifier used in auth instructions */
  	SIGN_LR_WITH_REG(x1)
 
 -	/* Use a stack frame allocated by our caller.  */
@@ -352,7 +352,7 @@ index 6a9a561..e83bc65 100644
 +	cfi_startproc
  	BTI_C
  	PAC_CFI_WINDOW_SAVE
- 	/* Sign the lr with x1 since that is the CFA which is the modifer used in auth instructions */
+ 	/* Sign the lr with x1 since that is the CFA which is the modifier used in auth instructions */
 @@ -348,8 +348,8 @@ CNAME(ffi_closure_SYSV_V):
  #endif
 

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -517,7 +517,7 @@ def python_build_info(
 
     bi["object_file_format"] = object_file_format
 
-    # Determine allowed libaries on Linux
+    # Determine allowed libraries on Linux
     libs = extra_metadata["python_config_vars"].get("LIBS", "").split()
     mips = target_triple.split("-")[0] in {"mips", "mipsel"}
     linux_allowed_system_libraries = LINUX_ALLOW_SYSTEM_LIBRARIES.copy()

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1576,7 +1576,7 @@ def build_cpython(
         # import their contents. According to
         # https://github.com/pypa/pip/issues/11146 running pip from a wheel is not
         # supported. But it has historically worked and is simple. So do this until
-        # it stops working and we need to switch to running pip from the filesytem.
+        # it stops working and we need to switch to running pip from the filesystem.
         pip_env = dict(os.environ)
         pip_env["PYTHONPATH"] = str(pip_wheel)
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -87,7 +87,7 @@ Visual Studio 2017 (or later) is required. A compatible Windows SDK is required
 (10.0.17763.0 as per CPython 3.7.2).
 
 * A ``git.exe`` on ``PATH`` (to clone ``libffi`` from source).
-* An installation of Cywgin with the ``autoconf``, ``automake``, ``libtool``,
+* An installation of Cygwin with the ``autoconf``, ``automake``, ``libtool``,
   and ``make`` packages installed. (``libffi`` build dependency.)
 
 To build a dynamically linked Python distribution for Windows x64::

--- a/docs/distributions.rst
+++ b/docs/distributions.rst
@@ -112,7 +112,7 @@ python_implementation_cache_tag
    (Version 5 or above only.)
 
 python_implementation_hex_version
-   Hexidecimal expression of implementation version.
+   Hexadecimal expression of implementation version.
 
    This is the value exposed by ``sys.implementation.hexversion``.
 
@@ -237,7 +237,7 @@ python_suffixes
    (Version 5 or above only.)
 
 python_bytecode_magic_number
-   Magic number to use for bytecode files, expressed as a hexidecimal
+   Magic number to use for bytecode files, expressed as a hexadecimal
    string.
 
    (Version 5 or above only.)

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -593,7 +593,7 @@ const ELF_BANNED_SYMBOLS: &[&str] = &[
 /// The list is obviously not complete.
 const DEPENDENCY_PACKAGE_SYMBOLS: &[&str] = &[
     /* TODO(geofft): Tk provides these as no-op stubs on macOS, make it
-     * stop doing that so we can reenable the check
+     * stop doing that so we can re-enable the check
      * // libX11
      * "XClearWindow",
      * "XFlush",


### PR DESCRIPTION
% `codespell --ignore-words-list=inout --skip="LICENSE.*,python-licenses.rst" --write-changes`
* https://pypi.org/project/codespell