### PR TITLE
Run `cargo fmt` and `cargo clippy --fix`

### DIFF
--- a/src/macho.rs
+++ b/src/macho.rs
@@ -4,7 +4,7 @@
 
 use {
     crate::validation::ValidationContext,
-    anyhow::{anyhow, Context, Result},
+    anyhow::{Context, Result, anyhow},
     apple_sdk::{AppleSdk, SdkSearch, SdkSearchLocation, SdkSorting, SdkVersion, SimpleSdk},
     semver::Version,
     std::{
@@ -53,7 +53,7 @@ impl std::fmt::Display for MachOPackedVersion {
         let minor = (self.value >> 8) & 0xff;
         let subminor = self.value & 0xff;
 
-        f.write_str(&format!("{}.{}.{}", major, minor, subminor))
+        f.write_str(&format!("{major}.{minor}.{subminor}"))
     }
 }
 
@@ -128,9 +128,9 @@ impl RequiredSymbols {
 fn tbd_relative_path(path: &str) -> Result<String> {
     if let Some(stripped) = path.strip_prefix('/') {
         if let Some(stem) = stripped.strip_suffix(".dylib") {
-            Ok(format!("{}.tbd", stem))
+            Ok(format!("{stem}.tbd"))
         } else {
-            Ok(format!("{}.tbd", stripped))
+            Ok(format!("{stripped}.tbd"))
         }
     } else {
         Err(anyhow!("could not determine tbd path from {}", path))
@@ -165,13 +165,13 @@ impl TbdMetadata {
                                     export
                                         .objc_classes
                                         .iter()
-                                        .map(|cls| format!("_OBJC_CLASS_${}", cls)),
+                                        .map(|cls| format!("_OBJC_CLASS_${cls}")),
                                 )
                                 .chain(
                                     export
                                         .objc_classes
                                         .iter()
-                                        .map(|cls| format!("_OBJC_METACLASS_${}", cls)),
+                                        .map(|cls| format!("_OBJC_METACLASS_${cls}")),
                                 ),
                         );
 
@@ -214,13 +214,13 @@ impl TbdMetadata {
                                             export
                                                 .objc_classes
                                                 .iter()
-                                                .map(|cls| format!("_OBJC_CLASS_$_{}", cls)),
+                                                .map(|cls| format!("_OBJC_CLASS_$_{cls}")),
                                         )
                                         .chain(
                                             export
                                                 .objc_classes
                                                 .iter()
-                                                .map(|cls| format!("_OBJC_METACLASS_$_{}", cls)),
+                                                .map(|cls| format!("_OBJC_METACLASS_$_{cls}")),
                                         ),
                                 );
 
@@ -249,13 +249,13 @@ impl TbdMetadata {
                                         export
                                             .objc_classes
                                             .iter()
-                                            .map(|cls| format!("_OBJC_CLASS_$_{}", cls)),
+                                            .map(|cls| format!("_OBJC_CLASS_$_{cls}")),
                                     )
                                     .chain(
                                         export
                                             .objc_classes
                                             .iter()
-                                            .map(|cls| format!("_OBJC_METACLASS_$_{}", cls)),
+                                            .map(|cls| format!("_OBJC_METACLASS_$_{cls}")),
                                     ),
                             );
                             res.weak_symbols
@@ -370,8 +370,7 @@ impl IndexedSdks {
             "x86_64-apple-darwin" => "x86_64-macos",
             _ => {
                 context.errors.push(format!(
-                    "unknown target triple for Mach-O symbol analysis: {}",
-                    triple
+                    "unknown target triple for Mach-O symbol analysis: {triple}"
                 ));
                 return Ok(());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ mod release;
 mod validation;
 
 use {
-    anyhow::{anyhow, Context, Result},
-    clap::{value_parser, Arg, ArgAction, Command},
+    anyhow::{Context, Result, anyhow},
+    clap::{Arg, ArgAction, Command, value_parser},
     std::{
         io::Read,
         path::{Path, PathBuf},
@@ -240,7 +240,7 @@ fn main() {
     let exit_code = match main_impl() {
         Ok(()) => 0,
         Err(err) => {
-            eprintln!("Error: {:?}", err);
+            eprintln!("Error: {err:?}");
             1
         }
     };

--- a/src/release.rs
+++ b/src/release.rs
@@ -13,7 +13,7 @@ use std::{
 use url::Url;
 use {
     crate::json::parse_python_json,
-    anyhow::{anyhow, Result},
+    anyhow::{Result, anyhow},
     once_cell::sync::Lazy,
     pep440_rs::VersionSpecifier,
     std::{
@@ -628,7 +628,7 @@ static LLVM_URL: Lazy<Url> = Lazy::new(|| {
 /// Returns the path to the top-level `llvm` directory.
 pub async fn bootstrap_llvm() -> Result<PathBuf> {
     let url = &*LLVM_URL;
-    let filename = url.path_segments().unwrap().last().unwrap();
+    let filename = url.path_segments().unwrap().next_back().unwrap();
 
     let llvm_dir = Path::new("build").join("llvm");
     std::fs::create_dir_all(&llvm_dir)?;
@@ -646,7 +646,7 @@ pub async fn bootstrap_llvm() -> Result<PathBuf> {
     // Download the tarball.
     let tarball_path = temp_dir
         .path()
-        .join(url.path_segments().unwrap().last().unwrap());
+        .join(url.path_segments().unwrap().next_back().unwrap());
     let mut tarball_file = tokio::fs::File::create(&tarball_path).await?;
     let mut bytes_stream = reqwest::Client::new()
         .get(url.clone())


### PR DESCRIPTION
This is from cargo 1.88, since 1.89 pulls in let-chains, and whatever version of Rust is in GitHub CI doesn't support them last time I tried. (We should upgrade it at some point, though, since our Rust usage is all internal.)