### PR TITLE
macOS CI: Stop setting $APPLE_SDK_PATH

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,15 +142,6 @@ jobs:
       - name: Build
         if: ${{ ! matrix.dry-run }}
         run: |
-          if [ "${MATRIX_TARGET_TRIPLE}" = "aarch64-apple-darwin" ]; then
-            export APPLE_SDK_PATH=/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk
-          elif [ "${MATRIX_TARGET_TRIPLE}" = "x86_64-apple-darwin" ]; then
-            export APPLE_SDK_PATH=/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk
-          else
-            echo "unhandled target triple: ${MATRIX_TARGET_TRIPLE}"
-            exit 1
-          fi
-
           ./build-macos.py --target-triple ${MATRIX_TARGET_TRIPLE} --python cpython-${MATRIX_PYTHON} --options ${MATRIX_BUILD_OPTIONS}
         env:
           MATRIX_TARGET_TRIPLE: ${{ matrix.target_triple }}


### PR DESCRIPTION
The build script supports locating this with `xcrun --show-sdk-path`. It looks like we originally started overriding this in CI to force use of the 10.15 SDK to work around issues with the 11.0 one (09ca2ac775). We should be able to support building with the newest SDK because we set `-mmacosx-version-min` / `MACOSX_DEPLOYMENT_TARGET` to a low value, and this keeps us robust to GitHub runner image changes. There are SDK compatibility tests, too.