### PR TITLE
Cross compile with LLVM and a sysroot for riscv64

### DIFF
--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -1,6 +1,6 @@
-# Debian Buster.
-FROM debian@sha256:2a0c1b9175adf759420fe0fbd7f5b449038319171eb76554bb76cbe172b62b42
-LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
+# Debian Trixie
+FROM debian@sha256:3352c2e13876c8a5c5873ef20870e1939e73cb9a3c1aeba5e3e72172a85ce9ed
+LABEL org.opencontainers.image.authors="Jonathan J. Helmus <jjhelmus@gmail.com>"
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \
@@ -17,9 +17,19 @@ ENV HOME=/build \
 CMD ["/bin/bash", "--login"]
 WORKDIR '/build'
 
+# curl
+RUN apt-get update && apt install --yes curl
+
+# Add the LLVM project repository
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+        -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && echo "deb http://apt.llvm.org/trixie/ llvm-toolchain-trixie-22 main" \
+        > /etc/apt/sources.list.d/llvm.list
+
+# Add buster as an source for riscv sysroot packages
 RUN for s in debian_buster debian_buster-updates debian-security_buster/updates; do \
       echo "deb http://snapshot.debian.org/archive/${s%_*}/20250109T084424Z/ ${s#*_} main"; \
-    done > /etc/apt/sources.list && \
+    done > /etc/apt/sources.list.d/buster.list && \
     ( echo 'quiet "true";'; \
       echo 'APT::Get::Assume-Yes "true";'; \
       echo 'APT::Install-Recommends "false";'; \
@@ -27,13 +37,15 @@ RUN for s in debian_buster debian_buster-updates debian-security_buster/updates;
       echo 'Acquire::Retries "5";'; \
     ) > /etc/apt/apt.conf.d/99cpython-portable
 
+# Pin the riscv sysroot packages to buster
+RUN printf 'Package: *-riscv64-cross\nPin: release n=buster\nPin-Priority: 900\n' \
+        > /etc/apt/preferences.d/buster-cross
+
 RUN apt-get update
 
 # Host building.
 RUN apt-get install \
     bzip2 \
-    gcc \
-    g++ \
     libc6-dev \
     libffi-dev \
     make \
@@ -46,32 +58,19 @@ RUN apt-get install \
     zip \
     zlib1g-dev
 
-# Cross-building.
+# LLVM
 RUN apt-get install \
-    g++-aarch64-linux-gnu \
-    g++-arm-linux-gnueabi \
-    g++-arm-linux-gnueabihf \
-    g++-mips-linux-gnu \
-    g++-mips64el-linux-gnuabi64 \
-    g++-mipsel-linux-gnu \
-    g++-powerpc64le-linux-gnu \
-    g++-riscv64-linux-gnu \
-    g++-s390x-linux-gnu \
-    gcc-aarch64-linux-gnu \
-    gcc-arm-linux-gnueabi \
-    gcc-arm-linux-gnueabihf \
-    gcc-mips-linux-gnu \
-    gcc-mips64el-linux-gnuabi64 \
-    gcc-mipsel-linux-gnu \
-    gcc-powerpc64le-linux-gnu \
-    gcc-riscv64-linux-gnu \
-    gcc-s390x-linux-gnu \
-    libc6-dev-arm64-cross \
-    libc6-dev-armel-cross \
-    libc6-dev-armhf-cross \
-    libc6-dev-mips-cross \
-    libc6-dev-mips64el-cross \
-    libc6-dev-mipsel-cross \
-    libc6-dev-ppc64el-cross \
+    clang-22 \
+    lld-22 \
+    llvm-22
+
+RUN apt-get install \
     libc6-dev-riscv64-cross \
-    libc6-dev-s390x-cross
+    libc6-riscv64-cross \
+    linux-libc-dev-riscv64-cross \
+    libgcc1-riscv64-cross \
+    libgcc-8-dev-riscv64-cross
+
+RUN ln -s /usr/bin/clang-22 /usr/bin/riscv64-linux-gnu-clang && \
+    ln -s /usr/bin/clang++-22 /usr/bin/riscv64-linux-gnu-clang++ && \
+    ln -s /usr/lib/llvm-22/bin/ld.lld /usr/bin/riscv64-linux-gnu-ld

--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -73,4 +73,5 @@ RUN apt-get install \
 
 RUN ln -s /usr/bin/clang-22 /usr/bin/riscv64-linux-gnu-clang && \
     ln -s /usr/bin/clang++-22 /usr/bin/riscv64-linux-gnu-clang++ && \
-    ln -s /usr/lib/llvm-22/bin/ld.lld /usr/bin/riscv64-linux-gnu-ld
+    ln -s /usr/lib/llvm-22/bin/ld.lld /usr/bin/riscv64-linux-gnu-ld && \
+    ln -s /usr/lib/llvm-22/bin/llvm-ar /usr/bin/riscv64-unknown-linux-gnu-llvm-ar

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -222,8 +222,10 @@ def toolchain_archive_path(package_name, host_platform):
     return BUILD / basename
 
 
-def install_binutils(platform):
-    return not platform.startswith("macos_")
+def install_binutils(host_platform, target_triple):
+    if "riscv64" in target_triple:
+        return False
+    return not host_platform.startswith("macos_")
 
 
 def simple_build(
@@ -247,7 +249,7 @@ def simple_build(
                 BUILD,
                 host_platform,
                 target_triple,
-                binutils=install_binutils(host_platform),
+                binutils=install_binutils(host_platform, target_triple),
                 clang=True,
                 musl="musl" in target_triple,
                 static="static" in build_options,
@@ -368,7 +370,7 @@ def build_libedit(
                 BUILD,
                 host_platform,
                 target_triple,
-                binutils=install_binutils(host_platform),
+                binutils=install_binutils(host_platform, target_triple),
                 clang=True,
                 musl="musl" in target_triple,
                 static="static" in build_options,
@@ -419,7 +421,7 @@ def build_cpython_host(
             BUILD,
             host_platform,
             target_triple,
-            binutils=install_binutils(host_platform),
+            binutils=install_binutils(host_platform, target_triple),
             clang=True,
             static="static" in build_options,
         )
@@ -752,7 +754,7 @@ def build_cpython(
                 BUILD,
                 host_platform,
                 target_triple,
-                binutils=install_binutils(host_platform),
+                binutils=install_binutils(host_platform, target_triple),
                 clang=True,
                 musl="musl" in target_triple,
                 static="static" in build_options,

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -456,7 +456,6 @@ riscv64-unknown-linux-gnu:
   needs:
     - autoconf
     - bdb
-    - binutils
     - bzip2
     - expat
     - libedit

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -436,6 +436,8 @@ ppc64le-unknown-linux-gnu:
 riscv64-unknown-linux-gnu:
   host_platforms:
     - linux_x86_64
+    - linux_aarch64
+    - macos_arm64
   pythons_supported:
     - '3.10'
     - '3.11'

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -444,10 +444,10 @@ riscv64-unknown-linux-gnu:
     - '3.14'
     - '3.15'
   docker_image_suffix: .cross-riscv64
-  host_cc: /usr/bin/x86_64-linux-gnu-gcc
-  host_cxx: /usr/bin/x86_64-linux-gnu-g++
-  target_cc: /usr/bin/riscv64-linux-gnu-gcc
-  target_cxx: /usr/bin/riscv64-linux-gnu-g++
+  host_cc: clang-22
+  host_cxx: clang++-22
+  target_cc: /usr/bin/riscv64-linux-gnu-clang
+  target_cxx: /usr/bin/riscv64-linux-gnu-clang++
   target_ldflags:
     # Hardening
     - '-Wl,-z,noexecstack'

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -262,7 +262,11 @@ static ELF_ALLOWED_LIBRARIES_BY_TRIPLE: Lazy<HashMap<&'static str, Vec<&'static 
             ("ppc64le-unknown-linux-gnu", vec!["ld64.so.1", "ld64.so.2"]),
             (
                 "riscv64-unknown-linux-gnu",
-                vec!["ld-linux-riscv64-lp64d.so.1", "libatomic.so.1"],
+                vec![
+                    "ld-linux-riscv64-lp64d.so.1",
+                    "libatomic.so.1",
+                    "libgcc_s.so.1",
+                ],
             ),
             ("s390x-unknown-linux-gnu", vec!["ld64.so.1"]),
             ("x86_64-unknown-linux-gnu", vec!["ld-linux-x86-64.so.2"]),


### PR DESCRIPTION
Use LLVM 22 and a Debian buster sysroot to cross-compile for riscv64.