### PR TITLE
Enable loongarch64-linux build

### DIFF
--- a/ci-matrix.py
+++ b/ci-matrix.py
@@ -26,6 +26,7 @@ DOCKER_BUILD_IMAGES = [
     {"name": "build", "arch": "x86_64"},
     {"name": "build.cross", "arch": "x86_64"},
     {"name": "build.cross-riscv64", "arch": "x86_64"},
+    {"name": "build.cross-loongarch64", "arch": "x86_64"},
     {"name": "build.debian9", "arch": "aarch64"},
     {"name": "gcc", "arch": "x86_64"},
     {"name": "gcc.debian9", "arch": "aarch64"},

--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -163,6 +163,27 @@ linux:
           - freethreaded+lto
         minimum-python-version: "3.13"
 
+  loongarch64-unknown-linux-gnu:
+    arch: loongarch64
+    libc: gnu
+    python_versions:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+      - "3.15"
+    build_options:
+      - debug
+      - noopt
+      - lto
+    build_options_conditional:
+      - options:
+          - freethreaded+debug
+          - freethreaded+noopt
+          - freethreaded+lto
+        minimum-python-version: "3.13"
+
   x86_64-unknown-linux-gnu:
     arch: x86_64
     libc: gnu

--- a/cpython-unix/build-libxcb.sh
+++ b/cpython-unix/build-libxcb.sh
@@ -13,12 +13,6 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
 tar -xf "libxcb-${LIBXCB_VERSION}.tar.gz"
 pushd "libxcb-${LIBXCB_VERSION}"
 
-if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
-    rm -f build-aux/config.guess build-aux/config.sub
-    curl -sSL -o build-aux/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess'
-    curl -sSL -o build-aux/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub'
-fi
-
 if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi

--- a/cpython-unix/build-xorgproto.sh
+++ b/cpython-unix/build-xorgproto.sh
@@ -15,12 +15,6 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf "xorgproto-${XORGPROTO_VERSION}.tar.gz"
 pushd "xorgproto-${XORGPROTO_VERSION}"
 
-if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
-    rm -f config.guess.sub config.sub
-    curl -sSL -o config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess'
-    curl -sSL -o config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub'
-fi
-
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
     --build="${BUILD_TRIPLE}" \
     --host="${TARGET_TRIPLE}" \

--- a/src/release.rs
+++ b/src/release.rs
@@ -187,6 +187,20 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     );
 
     h.insert(
+        "loongarch64-unknown-linux-gnu",
+        TripleRelease {
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
+            freethreaded_install_only_suffix: "freethreaded+lto",
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.10").unwrap()),
+            conditional_suffixes: vec![ConditionalSuffixes {
+                python_version_requirement: VersionSpecifier::from_str(">=3.13").unwrap(),
+                suffixes: linux_suffixes_nopgo_freethreaded.clone(),
+            }],
+        },
+    );
+
+    h.insert(
         "ppc64le-unknown-linux-gnu",
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -39,6 +39,7 @@ const RECOGNIZED_TRIPLES: &[&str] = &[
     "armv7-unknown-linux-gnueabihf",
     "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu",
+    "loongarch64-unknown-linux-gnu",
     // Note there's build support for mips* targets but they are not tested
     // See https://github.com/astral-sh/python-build-standalone/issues/412
     "mips-unknown-linux-gnu",
@@ -176,6 +177,10 @@ static GLIBC_MAX_VERSION_BY_TRIPLE: Lazy<HashMap<&'static str, version_compare::
             version_compare::Version::from("2.17").unwrap(),
         );
         versions.insert(
+            "loongarch64-unknown-linux-gnu",
+            version_compare::Version::from("2.38").unwrap(),
+        );
+        versions.insert(
             "mips-unknown-linux-gnu",
             version_compare::Version::from("2.19").unwrap(),
         );
@@ -253,6 +258,7 @@ static ELF_ALLOWED_LIBRARIES_BY_TRIPLE: Lazy<HashMap<&'static str, Vec<&'static 
                 vec!["ld-linux-armhf.so.3", "libgcc_s.so.1"],
             ),
             ("i686-unknown-linux-gnu", vec!["ld-linux-x86-64.so.2"]),
+            ("loongarch64-unknown-linux-gnu", vec!["ld-linux-loongarch-lp64d.so.1"]),
             ("mips-unknown-linux-gnu", vec!["ld.so.1", "libatomic.so.1"]),
             (
                 "mipsel-unknown-linux-gnu",
@@ -525,6 +531,7 @@ static PLATFORM_TAG_BY_TRIPLE: Lazy<HashMap<&'static str, &'static str>> = Lazy:
         ("armv7-unknown-linux-gnueabihf", "linux-arm"),
         ("i686-pc-windows-msvc", "win32"),
         ("i686-unknown-linux-gnu", "linux-i686"),
+        ("loongarch64-unknown-linux-gnu", "linux-loongarch64"),
         ("mips-unknown-linux-gnu", "linux-mips"),
         ("mipsel-unknown-linux-gnu", "linux-mipsel"),
         ("mips64el-unknown-linux-gnuabi64", "todo"),
@@ -925,6 +932,7 @@ fn validate_elf<Elf: FileHeader<Endian = Endianness>>(
         "armv7-unknown-linux-gnueabi" => object::elf::EM_ARM,
         "armv7-unknown-linux-gnueabihf" => object::elf::EM_ARM,
         "i686-unknown-linux-gnu" => object::elf::EM_386,
+        "loongarch64-unknown-linux-gnu" => object::elf::EM_LOONGARCH,
         "mips-unknown-linux-gnu" => object::elf::EM_MIPS,
         "mipsel-unknown-linux-gnu" => object::elf::EM_MIPS,
         "mips64el-unknown-linux-gnuabi64" => 0,


### PR DESCRIPTION
This patch officially enables the build and release pipeline for the `LoongArch64` architecture. 
While the underlying build scripts already contained initial support for `LoongArch64`, it was not hooked into the CI matrix or the release distribution logic.

- close: #204