### PR TITLE
update patchelf 0.13.1 -> 0.18.0

### DIFF
--- a/cpython-unix/build-patchelf.sh
+++ b/cpython-unix/build-patchelf.sh
@@ -11,7 +11,7 @@ export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
 tar -xf "patchelf-${PATCHELF_VERSION}.tar.bz2"
 
-pushd patchelf-0.13.1.20211127.72b6d44
+pushd "patchelf-${PATCHELF_VERSION}"
 
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
     ./configure \

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -273,10 +273,10 @@ DOWNLOADS = {
         "version": "2.16.03",
     },
     "patchelf": {
-        "url": "https://github.com/NixOS/patchelf/releases/download/0.13.1/patchelf-0.13.1.tar.bz2",
-        "size": 173598,
-        "sha256": "39e8aeccd7495d54df094d2b4a7c08010ff7777036faaf24f28e07777d1598e2",
-        "version": "0.13.1",
+        "url": "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0.tar.bz2",
+        "size": 423290,
+        "sha256": "1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b",
+        "version": "0.18.0",
     },
     "pip": {
         "url": "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl",


### PR DESCRIPTION
Update patchelf from 0.13.1 to 0.18.0.
This may address issues with loongarch64, see #1106 