### PR TITLE
Separate versions publishing privileges from release

### DIFF
--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -1,0 +1,105 @@
+# Publish python-build-standalone version information to the versions repository.
+name: publish-versions
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. 20260127)"
+        required: true
+        type: string
+      dry-run:
+        description: "Only generate metadata, skip PR creation"
+        required: false
+        type: boolean
+        default: true
+
+permissions: {}
+
+jobs:
+  publish-versions:
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      TAG: ${{ inputs.tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
+      - name: "Download SHA256SUMS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --dir dist --pattern "SHA256SUMS"
+
+      - name: "Generate versions metadata"
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ inputs.tag }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run generate-version-metadata.py > dist/versions.ndjson
+
+      - name: "Validate metadata"
+        run: |
+          echo "Generated $(wc -l < dist/versions.ndjson) version entries"
+          head -c 1000 dist/versions.ndjson
+
+      - name: "Set branch name"
+        if: inputs.dry-run != true
+        run: echo "BRANCH_NAME=update-versions-$TAG-$(date +%s)" >> $GITHUB_ENV
+
+      - name: "Clone versions repo"
+        if: inputs.dry-run != true
+        run: git clone https://${{ secrets.ASTRAL_VERSIONS_PAT }}@github.com/astral-sh/versions.git astral-versions
+
+      - name: "Update versions"
+        if: inputs.dry-run != true
+        run: cat dist/versions.ndjson | uv run astral-versions/scripts/insert-versions.py --name python-build-standalone
+
+      - name: "Commit versions"
+        if: inputs.dry-run != true
+        working-directory: astral-versions
+        run: |
+          git config user.name "astral-versions-bot"
+          git config user.email "176161322+astral-versions-bot@users.noreply.github.com"
+
+          git checkout -b "$BRANCH_NAME"
+          git add -A
+          git commit -m "Update python-build-standalone to $TAG"
+
+      - name: "Create Pull Request"
+        if: inputs.dry-run != true
+        working-directory: astral-versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
+        run: |
+          pull_request_title="Update python-build-standalone versions for $TAG"
+
+          gh pr list --state open --json title --jq ".[] | select(.title == \"$pull_request_title\") | .number" | \
+            xargs -I {} gh pr close {}
+
+          git push origin "$BRANCH_NAME"
+
+          gh pr create --base main --head "$BRANCH_NAME" \
+            --title "$pull_request_title" \
+            --body "Automated versions update for $TAG" \
+            --label "automation"
+
+      - name: "Merge Pull Request"
+        if: inputs.dry-run != true
+        working-directory: astral-versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
+        run: |
+          # Wait for PR to be created before merging
+          sleep 10
+          gh pr merge --squash "$BRANCH_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,72 +113,10 @@ jobs:
               ${VERSION}
           fi
 
-      - name: Generate versions metadata
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: uv run generate-version-metadata.py > dist/versions.ndjson
-
-      - name: Validate metadata
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        run: |
-          echo "Generated $(wc -l < dist/versions.ndjson) version entries"
-          head -c 1000 dist/versions.ndjson
-
-      - name: Set branch name
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          TAG: ${{ github.event.inputs.tag }}
-        run: echo "BRANCH_NAME=update-versions-$TAG-$(date +%s)" >> $GITHUB_ENV
-
-      - name: Clone versions repo
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        run: git clone https://${{ secrets.ASTRAL_VERSIONS_PAT }}@github.com/astral-sh/versions.git astral-versions
-
-      - name: Update versions
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        run: cat dist/versions.ndjson | uv run astral-versions/scripts/insert-versions.py --name python-build-standalone
-
-      - name: Commit versions
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          TAG: ${{ github.event.inputs.tag }}
-        working-directory: astral-versions
-        run: |
-          git config user.name "astral-versions-bot"
-          git config user.email "176161322+astral-versions-bot@users.noreply.github.com"
-
-          git checkout -b "$BRANCH_NAME"
-          git add -A
-          git commit -m "Update python-build-standalone to $TAG"
-
-      - name: Create Pull Request
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          TAG: ${{ github.event.inputs.tag }}
-          GH_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
-        working-directory: astral-versions
-        run: |
-          pull_request_title="Update python-build-standalone versions for $TAG"
-
-          gh pr list --state open --json title --jq ".[] | select(.title == \"$pull_request_title\") | .number" | \
-            xargs -I {} gh pr close {}
-
-          git push origin "$BRANCH_NAME"
-
-          gh pr create --base main --head "$BRANCH_NAME" \
-            --title "$pull_request_title" \
-            --body "Automated versions update for $TAG" \
-            --label "automation"
-
-      - name: Merge Pull Request
-        if: ${{ github.event.inputs.dry-run == 'false' }}
-        env:
-          GH_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
-        working-directory: astral-versions
-        run: |
-          # Wait for PR to be created before merging
-          sleep 10
-          gh pr merge --squash "$BRANCH_NAME"
-
+  publish-versions:
+    needs: release
+    if: ${{ github.event.inputs.dry-run == 'false' }}
+    uses: ./.github/workflows/publish-versions.yml
+    with:
+      tag: ${{ github.event.inputs.tag }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
This moves versions publishing back into a dedicated reusable workflow, keeping the release job limited to release creation and artifact publication instead of executing code from the external `versions` repository under the release token. The versions workflow remains isolated with empty top-level permissions and no persisted checkout credentials, preserving the intended least-privilege boundary.
