### PR TITLE
run build.py in frozen mode

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run --no-dev
+#!/usr/bin/env -S uv run --no-dev --frozen
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Run build.py with the `--frozen` option to prevent updates to `uv.lock`.