### PR TITLE
Enable BOLT on aarch64-unknown-linux-gnu

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -504,7 +504,6 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
 -reorder-blocks=ext-tsp \
 -reorder-functions=cdsort \
 -split-functions \
--split-strategy=cdsplit \
 -icf=safe \
 -inline-all \
 -split-eh \
@@ -512,16 +511,18 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
 -peepholes=none \
 -jump-tables=aggressive \
 -inline-ap \
--indirect-call-promotion=all \
--dyno-stats \
--frame-opt=hot"
+-dyno-stats"
         if [[ "${TARGET_TRIPLE}" == aarch64* ]]; then
             # CDSplit requires the prohibitively slow compact code model on
-            # AArch64, indirect-call promotion crashes on calls, and frame
-            # optimization is only supported on x86.
-            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/-split-strategy=cdsplit/-split-strategy=profile2}"
-            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/-indirect-call-promotion=all/-indirect-call-promotion=jump-tables}"
-            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/ -frame-opt=hot/}"
+            # AArch64, and indirect-call promotion crashes on calls.
+            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS} \
+-split-strategy=profile2 \
+-indirect-call-promotion=jump-tables"
+        elif [[ "${TARGET_TRIPLE}" == x86_64* ]]; then
+            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS} \
+-split-strategy=cdsplit \
+-indirect-call-promotion=all \
+-frame-opt=hot"
         fi
     fi
 

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -515,6 +515,14 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
 -indirect-call-promotion=all \
 -dyno-stats \
 -frame-opt=hot"
+        if [[ "${TARGET_TRIPLE}" == aarch64* ]]; then
+            # CDSplit requires the prohibitively slow compact code model on
+            # AArch64, indirect-call promotion crashes on calls, and frame
+            # optimization is only supported on x86.
+            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/-split-strategy=cdsplit/-split-strategy=profile2}"
+            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/-indirect-call-promotion=all/-indirect-call-promotion=jump-tables}"
+            BOLT_APPLY_FLAGS="${BOLT_APPLY_FLAGS/ -frame-opt=hot/}"
+        fi
     fi
 
     # Allow users to enable the experimental JIT on 3.13+

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -108,6 +108,7 @@ _csv:
     - _csv.c
 
 _ctypes:
+  build-mode: shared
   sources:
     - _ctypes/_ctypes.c
     - _ctypes/callbacks.c

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -129,6 +129,8 @@ _ctypes:
     - HAVE_FFI_PREP_CLOSURE_LOC=1
     - HAVE_FFI_CLOSURE_ALLOC=1
   defines-conditional:
+    - define: Py_BUILD_CORE_MODULE
+      maximum-python-version: "3.10"
     - define: MACOSX
       targets:
         - .*-apple-.*

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -178,11 +178,7 @@ aarch64-unknown-linux-gnu:
     - zlib
     - zstd
   openssl_target: linux-aarch64
-  # Blocked on:
-  #   BOLT-ERROR: Cannot relax adr in non-simple function
-  #   trampoline_code_table/1. Use --strict option to override
-  # See https://github.com/llvm/llvm-project/issues/146541
-  # bolt_capable: true
+  bolt_capable: true
 
 armv7-unknown-linux-gnueabi:
   linux_uapi_include_arch: arm-linux-gnueabi

--- a/pythonbuild/cpython.py
+++ b/pythonbuild/cpython.py
@@ -697,7 +697,7 @@ def derive_setup_local(
 
     for target in sorted(extra_cflags):
         make_lines.append(
-            b"%s: PY_STDMODULE_CFLAGS += %s" % (target, b" ".join(extra_cflags[target]))
+            b"%s: PY_CPPFLAGS += %s" % (target, b" ".join(extra_cflags[target]))
         )
 
     return {

--- a/pythonbuild/cpython.py
+++ b/pythonbuild/cpython.py
@@ -465,7 +465,7 @@ def derive_setup_local(
     # agrees fully with the distribution's knowledge of extensions. So we can
     # treat our metadata as canonical.
 
-    RE_DEFINE = re.compile(rb"-D[^=]+=[^\s]+")
+    RE_DEFINE = re.compile(rb"-D[^=\s]+=[^\s]+")
 
     # Translate our YAML metadata into Setup lines.
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -865,6 +865,7 @@ const GLOBAL_EXTENSIONS_WINDOWS_NO_STATIC: &[&str] = &["_testinternalcapi", "_tk
 /// Extension modules that should be built as shared libraries.
 const SHARED_LIBRARY_EXTENSIONS: &[&str] = &[
     "_crypt",
+    "_ctypes",
     "_ctypes_test",
     "_dbm",
     "_testbuffer",


### PR DESCRIPTION
Enable BOLT optimization during CPython build on the aarch64-unknown-linux-gnu platform.

To avoid https://github.com/llvm/llvm-project/issues/146541 the `_ctypes` extension is built as a shared module, causing the libffi trampoline code to exists in the extension rather than the `python` binary.

An alternative is to disable these static trampolines using `--disable-exec-static-tramp` when building libffi but this requires writable and executable memory segments which comes with security risks.