### PR TITLE
Add ppc64le power9, power10, and power11 optimized build targets

### DIFF
--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -142,6 +142,71 @@ linux:
           - freethreaded+lto
         minimum-python-version: "3.13"
 
+  ppc64le_power9-unknown-linux-gnu:
+    arch: ppc64le
+    arch_variant: power9
+    libc: gnu
+    python_versions:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+      - "3.15"
+    build_options:
+      - debug
+      - noopt
+      - lto
+    build_options_conditional:
+      - options:
+          - freethreaded+debug
+          - freethreaded+noopt
+          - freethreaded+lto
+        minimum-python-version: "3.13"
+  ppc64le_power10-unknown-linux-gnu:
+    arch: ppc64le
+    arch_variant: power10
+    libc: gnu
+    python_versions:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+      - "3.15"
+    build_options:
+      - debug
+      - noopt
+      - lto
+    build_options_conditional:
+      - options:
+          - freethreaded+debug
+          - freethreaded+noopt
+          - freethreaded+lto
+        minimum-python-version: "3.13"
+
+  ppc64le_power11-unknown-linux-gnu:
+    arch: ppc64le
+    arch_variant: power11
+    libc: gnu
+    python_versions:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+      - "3.15"
+    build_options:
+      - debug
+      - noopt
+      - lto
+    build_options_conditional:
+      - options:
+          - freethreaded+debug
+          - freethreaded+noopt
+          - freethreaded+lto
+        minimum-python-version: "3.13"
+
   riscv64-unknown-linux-gnu:
     arch: riscv64
     libc: gnu

--- a/cpython-unix/build.cross-ppc64le_power10.Dockerfile
+++ b/cpython-unix/build.cross-ppc64le_power10.Dockerfile
@@ -1,0 +1,54 @@
+# Debian Bookworm.
+FROM docker.io/library/debian@sha256:6bc30d909583f38600edd6609e29eb3fb284ab8affce8d0389f332fc91c2dd91
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
+
+RUN groupadd -g 1000 build && \
+    useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \
+    mkdir /tools && \
+    chown -R build:build /build /tools
+
+ENV HOME=/build \
+    SHELL=/bin/bash \
+    USER=build \
+    LOGNAME=build \
+    HOSTNAME=builder \
+    DEBIAN_FRONTEND=noninteractive
+
+CMD ["/bin/bash", "--login"]
+WORKDIR '/build'
+
+RUN printf '%s\n' \
+      'deb https://deb.debian.org/debian bookworm main' \
+      'deb https://deb.debian.org/debian bookworm-updates main' \
+      'deb https://deb.debian.org/debian-security bookworm-security main' \
+    > /etc/apt/sources.list && \
+    ( echo 'APT::Get::Assume-Yes "true";'; \
+      echo 'APT::Install-Recommends "false";'; \
+      echo 'Acquire::Retries "5";'; \
+      echo 'Acquire::https::Verify-Peer "false";'; \
+    ) > /etc/apt/apt.conf.d/99cpython-portable && \
+    rm -f /etc/apt/sources.list.d/* && \
+    apt-get update
+
+# Host building.
+RUN apt-get install \
+    bzip2 \
+    gcc \
+    g++ \
+    libc6-dev \
+    libffi-dev \
+    make \
+    patch \
+    perl \
+    pkg-config \
+    tar \
+    xz-utils \
+    unzip \
+    zip \
+    zlib1g-dev
+
+# Cross-building.
+RUN apt-get install \
+    g++-powerpc64le-linux-gnu \
+    gcc-powerpc64le-linux-gnu \
+    libc6-dev-ppc64el-cross

--- a/cpython-unix/build.cross-ppc64le_power11.Dockerfile
+++ b/cpython-unix/build.cross-ppc64le_power11.Dockerfile
@@ -1,0 +1,58 @@
+# Debian Bookworm + GCC 14 from Trixie.
+FROM docker.io/library/debian@sha256:6bc30d909583f38600edd6609e29eb3fb284ab8affce8d0389f332fc91c2dd91
+LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
+
+RUN groupadd -g 1000 build && \
+    useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \
+    mkdir /tools && \
+    chown -R build:build /build /tools
+
+ENV HOME=/build \
+    SHELL=/bin/bash \
+    USER=build \
+    LOGNAME=build \
+    HOSTNAME=builder \
+    DEBIAN_FRONTEND=noninteractive
+
+CMD ["/bin/bash", "--login"]
+WORKDIR '/build'
+
+RUN printf '%s\n' \
+      'deb https://deb.debian.org/debian bookworm main' \
+      'deb https://deb.debian.org/debian bookworm-updates main' \
+      'deb https://deb.debian.org/debian-security bookworm-security main' \
+      'deb https://deb.debian.org/debian trixie main' \
+    > /etc/apt/sources.list && \
+    ( echo 'APT::Get::Assume-Yes "true";'; \
+      echo 'APT::Install-Recommends "false";'; \
+      echo 'APT::Default-Release "bookworm";'; \
+      echo 'Acquire::Retries "5";'; \
+      echo 'Acquire::https::Verify-Peer "false";'; \
+    ) > /etc/apt/apt.conf.d/99cpython-portable && \
+    rm -f /etc/apt/sources.list.d/* && \
+    apt-get update
+
+# Host building.
+RUN apt-get install \
+    bzip2 \
+    gcc \
+    g++ \
+    libc6-dev \
+    libffi-dev \
+    make \
+    patch \
+    perl \
+    pkg-config \
+    tar \
+    xz-utils \
+    unzip \
+    zip \
+    zlib1g-dev
+
+# Cross-building.
+RUN apt-get install -t trixie \
+    binutils-powerpc64le-linux-gnu \
+    gcc-14-powerpc64le-linux-gnu \
+    g++-14-powerpc64le-linux-gnu && \
+    apt-get install \
+    libc6-dev-ppc64el-cross

--- a/cpython-unix/build.cross.Dockerfile
+++ b/cpython-unix/build.cross.Dockerfile
@@ -1,5 +1,5 @@
 # Debian Stretch.
-FROM debian@sha256:cebe6e1c30384958d471467e231f740e8f0fd92cbfd2a435a186e9bada3aee1c
+FROM docker.io/library/debian@sha256:cebe6e1c30384958d471467e231f740e8f0fd92cbfd2a435a186e9bada3aee1c
 LABEL org.opencontainers.image.authors="Gregory Szorc <gregory.szorc@gmail.com>"
 
 RUN groupadd -g 1000 build && \
@@ -17,12 +17,11 @@ ENV HOME=/build \
 CMD ["/bin/bash", "--login"]
 WORKDIR '/build'
 
-# Stretch stopped publishing snapshots in April 2023. Last snapshot
-# is 20230423T032533Z. But there are package authentication issues
-# with this snapshot.
-RUN for s in debian_stretch debian_stretch-updates debian-security_stretch/updates; do \
-      echo "deb http://snapshot.debian.org/archive/${s%_*}/20221105T150728Z/ ${s#*_} main"; \
-    done > /etc/apt/sources.list && \
+RUN printf '%s\n' \
+      'deb https://archive.debian.org/debian stretch main contrib' \
+      'deb https://archive.debian.org/debian stretch-updates main contrib' \
+      'deb https://archive.debian.org/debian-security stretch/updates main' \
+    > /etc/apt/sources.list && \
     ( echo 'quiet "true";'; \
       echo 'APT::Get::Assume-Yes "true";'; \
       echo 'APT::Install-Recommends "false";'; \

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -114,6 +114,9 @@ def add_target_env(env, build_platform, target_triple, build_env, build_options)
             target_triple.replace("x86_64_v2-", "x86_64-")
             .replace("x86_64_v3-", "x86_64-")
             .replace("x86_64_v4-", "x86_64-")
+            .replace("ppc64le_power9-", "ppc64le-")
+            .replace("ppc64le_power10-", "ppc64le-")
+            .replace("ppc64le_power11-", "ppc64le-")
         )
 
         # On macOS, we support building Linux in a virtualized container that

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -519,6 +519,171 @@ ppc64le-unknown-linux-gnu:
     - zstd
   openssl_target: linux-ppc64le
 
+ppc64le_power9-unknown-linux-gnu:
+  linux_uapi_include_arch: powerpc64le-linux-gnu
+  host_platforms:
+    - linux_x86_64
+  pythons_supported:
+    - '3.10'
+    - '3.11'
+    - '3.12'
+    - '3.13'
+    - '3.14'
+    - '3.15'
+  docker_image_suffix: .cross
+  host_cc: /usr/bin/x86_64-linux-gnu-gcc
+  host_cxx: /usr/bin/x86_64-linux-gnu-g++
+  target_cc: /usr/bin/powerpc64le-linux-gnu-gcc
+  target_cxx: /usr/bin/powerpc64le-linux-gnu-g++
+  target_cflags:
+    # Hardening
+    - '-fstack-protector'
+    - '-U_FORTIFY_SOURCE'
+    - '-D_FORTIFY_SOURCE=2'
+    - '-mcpu=power9'
+    - '-mtune=power9'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
+    - '-Wl,-z,relro'
+    - '-Wl,-z,now'
+  needs:
+    - autoconf
+    - bdb
+    - binutils
+    - bzip2
+    - expat
+    - libedit
+    - libffi
+    - libX11
+    - libXau
+    - libxcb
+    - linux-uapi
+    - m4
+    - mpdecimal
+    - ncurses
+    - openssl-3.5
+    - patchelf
+    - sqlite
+    - tcl
+    - tk
+    - uuid
+    - xorgproto
+    - xz
+    - zlib
+    - zstd
+  openssl_target: linux-ppc64le
+
+ppc64le_power10-unknown-linux-gnu:
+  linux_uapi_include_arch: powerpc64le-linux-gnu
+  host_platforms:
+    - linux_x86_64
+  pythons_supported:
+    - '3.10'
+    - '3.11'
+    - '3.12'
+    - '3.13'
+    - '3.14'
+    - '3.15'
+  docker_image_suffix: .cross-ppc64le_power10
+  host_cc: /usr/bin/x86_64-linux-gnu-gcc
+  host_cxx: /usr/bin/x86_64-linux-gnu-g++
+  target_cc: /usr/bin/powerpc64le-linux-gnu-gcc
+  target_cxx: /usr/bin/powerpc64le-linux-gnu-g++
+  target_cflags:
+    # Hardening
+    - '-fstack-protector'
+    - '-U_FORTIFY_SOURCE'
+    - '-D_FORTIFY_SOURCE=2'
+    - '-mcpu=power10'
+    - '-mtune=power10'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
+    - '-Wl,-z,relro'
+    - '-Wl,-z,now'
+  needs:
+    - autoconf
+    - bdb
+    - binutils
+    - bzip2
+    - expat
+    - libedit
+    - libffi
+    - libX11
+    - libXau
+    - libxcb
+    - linux-uapi
+    - m4
+    - mpdecimal
+    - ncurses
+    - openssl-3.5
+    - patchelf
+    - sqlite
+    - tcl
+    - tk
+    - uuid
+    - xorgproto
+    - xz
+    - zlib
+    - zstd
+  openssl_target: linux-ppc64le
+
+ppc64le_power11-unknown-linux-gnu:
+  linux_uapi_include_arch: powerpc64le-linux-gnu
+  host_platforms:
+    - linux_x86_64
+  pythons_supported:
+    - '3.10'
+    - '3.11'
+    - '3.12'
+    - '3.13'
+    - '3.14'
+    - '3.15'
+  docker_image_suffix: .cross-ppc64le_power11
+  host_cc: /usr/bin/x86_64-linux-gnu-gcc
+  host_cxx: /usr/bin/x86_64-linux-gnu-g++
+  target_cc: /usr/bin/powerpc64le-linux-gnu-gcc-14
+  target_cxx: /usr/bin/powerpc64le-linux-gnu-g++-14
+  target_cflags:
+    # Hardening
+    - '-fstack-protector'
+    - '-U_FORTIFY_SOURCE'
+    - '-D_FORTIFY_SOURCE=2'
+    - '-mcpu=power11'
+    - '-mtune=power11'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
+    - '-Wl,-z,relro'
+    - '-Wl,-z,now'
+  needs:
+    - autoconf
+    - bdb
+    - binutils
+    - bzip2
+    - expat
+    - libedit
+    - libffi
+    - libX11
+    - libXau
+    - libxcb
+    - linux-uapi
+    - m4
+    - mpdecimal
+    - ncurses
+    - openssl-3.5
+    - patchelf
+    - sqlite
+    - tcl
+    - tk
+    - uuid
+    - xorgproto
+    - xz
+    - zlib
+    - zstd
+  openssl_target: linux-ppc64le
+
 riscv64-unknown-linux-gnu:
   linux_uapi_include_arch: riscv64-linux-gnu
   host_platforms:

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -90,6 +90,24 @@ Distributions are produced for the following target triples:
    For example, this target supports AWS Graviton EC2 instances. Many
    Linux ARM devices are also ``aarch64``.
 
+``ppc64le-unknown-linux-gnu``
+   Linux on 64-bit little-endian PowerPC (ELFv2 ABI baseline).
+
+``ppc64le_power9-unknown-linux-gnu``
+   Linux on 64-bit little-endian PowerPC optimized for POWER9.
+
+   Compiled with ``-mcpu=power9 -mtune=power9``.
+
+``ppc64le_power10-unknown-linux-gnu``
+   Linux on 64-bit little-endian PowerPC optimized for POWER10.
+
+   Compiled with ``-mcpu=power10 -mtune=power10``.
+
+``ppc64le_power11-unknown-linux-gnu``
+   Linux on 64-bit little-endian PowerPC optimized for POWER11.
+
+   Compiled with ``-mcpu=power11 -mtune=power11``.
+
 ``x86_64_v2-*``
    Targets 64-bit Intel/AMD CPUs approximately newer than
    `Nehalem <https://en.wikipedia.org/wiki/Nehalem_(microarchitecture)>`_

--- a/pythonbuild/downloads.json
+++ b/pythonbuild/downloads.json
@@ -165,7 +165,7 @@
         "version": "0.5"
     },
     "libX11": {
-        "url": "https://www.x.org/releases/individual/lib/libX11-1.8.13.tar.gz",
+        "url": "https://xorg.freedesktop.org/archive/individual/lib/libX11-1.8.13.tar.gz",
         "size": 3217264,
         "sha256": "acf0e7cd7541110e6330ecb539441a2d53061f386ec7be6906dfde0de2598470",
         "version": "1.8.13",
@@ -180,7 +180,7 @@
         "license_file": "LICENSE.libX11.txt"
     },
     "libXau": {
-        "url": "https://www.x.org/releases/individual/lib/libXau-1.0.12.tar.gz",
+        "url": "https://xorg.freedesktop.org/archive/individual/lib/libXau-1.0.12.tar.gz",
         "size": 418722,
         "sha256": "2402dd938da4d0a332349ab3d3586606175e19cb32cb9fe013c19f1dc922dcee",
         "version": "1.0.12",
@@ -393,7 +393,7 @@
         "license_file": "LICENSE.tix.txt"
     },
     "tk": {
-        "url": "https://prdownloads.sourceforge.net/tcl/tk9.0.4-src.tar.gz",
+        "url": "https://downloads.sourceforge.net/project/tcl/Tcl/9.0.4/tk9.0.4-src.tar.gz",
         "size": 4613019,
         "sha256": "d7a146d2917eb8b5cc95276dbf0e3d03c7464d2b19c1675357857c989301dbb4",
         "version": "9.0.4",
@@ -478,7 +478,7 @@
         "version": "1.17.0"
     },
     "xorgproto": {
-        "url": "https://www.x.org/releases/individual/proto/xorgproto-2025.1.tar.gz",
+        "url": "https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2025.1.tar.gz",
         "size": 1127613,
         "sha256": "d6f89f65bafb8c9b735e0515882b8a1511e8e864dde5e9513e191629369f2256",
         "version": "2025.1"

--- a/src/release.rs
+++ b/src/release.rs
@@ -202,7 +202,25 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
             }],
         },
     );
-
+    for triple in [
+        "ppc64le_power9-unknown-linux-gnu",
+        "ppc64le_power10-unknown-linux-gnu",
+        "ppc64le_power11-unknown-linux-gnu",
+    ] {
+        h.insert(
+            triple,
+            TripleRelease {
+                suffixes: linux_suffixes_nopgo.clone(),
+                install_only_suffix: "lto",
+                freethreaded_install_only_suffix: "freethreaded+lto",
+                python_version_requirement: Some(VersionSpecifier::from_str(">=3.10").unwrap()),
+                conditional_suffixes: vec![ConditionalSuffixes {
+                    python_version_requirement: VersionSpecifier::from_str(">=3.13").unwrap(),
+                    suffixes: linux_suffixes_nopgo_freethreaded.clone(),
+                }],
+            },
+        );
+    }
     h.insert(
         "riscv64-unknown-linux-gnu",
         TripleRelease {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -47,6 +47,9 @@ const RECOGNIZED_TRIPLES: &[&str] = &[
     "mipsel-unknown-linux-gnu",
     "mips64el-unknown-linux-gnuabi64",
     "ppc64le-unknown-linux-gnu",
+    "ppc64le_power9-unknown-linux-gnu",
+    "ppc64le_power10-unknown-linux-gnu",
+    "ppc64le_power11-unknown-linux-gnu",
     "riscv64-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",
     "x86_64-apple-darwin",
@@ -203,6 +206,18 @@ static GLIBC_MAX_VERSION_BY_TRIPLE: Lazy<HashMap<&'static str, version_compare::
             version_compare::Version::from("2.17").unwrap(),
         );
         versions.insert(
+            "ppc64le_power9-unknown-linux-gnu",
+            version_compare::Version::from("2.17").unwrap(),
+        );
+        versions.insert(
+            "ppc64le_power10-unknown-linux-gnu",
+            version_compare::Version::from("2.36").unwrap(),
+        );
+        versions.insert(
+            "ppc64le_power11-unknown-linux-gnu",
+            version_compare::Version::from("2.36").unwrap(),
+        );
+        versions.insert(
             "riscv64-unknown-linux-gnu",
             version_compare::Version::from("2.28").unwrap(),
         );
@@ -275,6 +290,18 @@ static ELF_ALLOWED_LIBRARIES_BY_TRIPLE: Lazy<HashMap<&'static str, Vec<&'static 
             ),
             ("mips64el-unknown-linux-gnuabi64", vec![]),
             ("ppc64le-unknown-linux-gnu", vec!["ld64.so.1", "ld64.so.2"]),
+            (
+                "ppc64le_power9-unknown-linux-gnu",
+                vec!["ld64.so.1", "ld64.so.2"],
+            ),
+            (
+                "ppc64le_power10-unknown-linux-gnu",
+                vec!["ld64.so.1", "ld64.so.2"],
+            ),
+            (
+                "ppc64le_power11-unknown-linux-gnu",
+                vec!["ld64.so.1", "ld64.so.2"],
+            ),
             (
                 "riscv64-unknown-linux-gnu",
                 vec!["ld-linux-riscv64-lp64d.so.1", "libatomic.so.1"],
@@ -556,6 +583,9 @@ static PLATFORM_TAG_BY_TRIPLE: Lazy<HashMap<&'static str, &'static str>> = Lazy:
         ("mipsel-unknown-linux-gnu", "linux-mipsel"),
         ("mips64el-unknown-linux-gnuabi64", "todo"),
         ("ppc64le-unknown-linux-gnu", "linux-powerpc64le"),
+        ("ppc64le_power9-unknown-linux-gnu", "linux-powerpc64le"),
+        ("ppc64le_power10-unknown-linux-gnu", "linux-powerpc64le"),
+        ("ppc64le_power11-unknown-linux-gnu", "linux-powerpc64le"),
         ("riscv64-unknown-linux-gnu", "linux-riscv64"),
         ("s390x-unknown-linux-gnu", "linux-s390x"),
         ("x86_64-apple-darwin", "macosx-10.15-x86_64"),
@@ -968,6 +998,9 @@ fn validate_elf<Elf: FileHeader<Endian = Endianness>>(
         "mipsel-unknown-linux-gnu" => object::elf::EM_MIPS,
         "mips64el-unknown-linux-gnuabi64" => 0,
         "ppc64le-unknown-linux-gnu" => object::elf::EM_PPC64,
+        "ppc64le_power9-unknown-linux-gnu" => object::elf::EM_PPC64,
+        "ppc64le_power10-unknown-linux-gnu" => object::elf::EM_PPC64,
+        "ppc64le_power11-unknown-linux-gnu" => object::elf::EM_PPC64,
         "riscv64-unknown-linux-gnu" => object::elf::EM_RISCV,
         "s390x-unknown-linux-gnu" => object::elf::EM_S390,
         "x86_64-unknown-linux-gnu" => object::elf::EM_X86_64,


### PR DESCRIPTION
Adds three new ppc64le architecture variant targets, mirroring the existing
x86_64_v2/v3/v4 pattern:

- `ppc64le_power9-unknown-linux-gnu` — compiled with `-mcpu=power9 -mtune=power9`
- `ppc64le_power10-unknown-linux-gnu` — compiled with `-mcpu=power10 -mtune=power10`
- `ppc64le_power11-unknown-linux-gnu` — compiled with `-mcpu=power11 -mtune=power11`

The existing generic `ppc64le-unknown-linux-gnu` artifact is untouched.

Power9 support is based on Christy Norman's work (clnperez/python-build-standalone#1).
Power10 uses Debian Bookworm's GCC 12. Power11 uses GCC 14 from Debian Trixie because
GCC 12 does not support `-mcpu=power11`.

> **Note:** `ppc64le_power10` and `ppc64le_power11` require glibc ≥ 2.36 at runtime
> (enforced in `validation.rs`). This is a consequence of using Debian Bookworm as the
> build base. The existing `ppc64le-unknown-linux-gnu` and `ppc64le_power9` targets
> retain glibc 2.17 compatibility.

Closes #1215
