### PR TITLE
disable _testclinic in all Python versions

### DIFF
--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -726,7 +726,6 @@ _testcapi:
       minimum-python-version: "3.13"
 
 _testclinic:
-  minimum-python-version: '3.12'
   disabled-targets:
     - .*
   sources:

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -2027,9 +2027,7 @@ fn validate_distribution(
         let mut entry = entry.map_err(|e| anyhow!("failed to iterate over archive: {}", e))?;
         let path = entry.path()?.to_path_buf();
 
-        // TODO(jjh): Do not include shared modules in Python 3.10, 3.11 static builds
-        // https://github.com/astral-sh/python-build-standalone/issues/1222
-        if is_static && !matches!(python_major_minor, "3.10" | "3.11") && is_shared_library(&path) {
+        if is_static && is_shared_library(&path) {
             context.errors.push(format!(
                 "static distribution contains shared library {}",
                 path.display()


### PR DESCRIPTION
The `_testclinic` module introduced in 3.12.0 was backported to 3.10 (https://github.com/python/cpython/commit/3144aca3dae51d3d88cc58fd8e9a04d6d6601ced) and 3.11 (https://github.com/python/cpython/commit/dd323afea81523482e14c57eaebd6d3c7d61c212). 

Disable the module on all Python versions as it is only needed for testing.

closes #1222