### PR TITLE
Emit GNU build IDs on Linux targets

### DIFF
--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -45,6 +45,11 @@
 #
 #    Values will be added to LDFLAGS.
 #
+#    Linux targets pass -Wl,--build-id=sha1 so binaries carry a GNU build ID.
+#    Debuginfod is keyed entirely on that ID, so without it debuggers cannot
+#    request debug symbols for these distributions at all. sha1 is derived from
+#    the linked content, so it does not affect build reproducibility.
+#
 # apple_sdk_platform
 #    Name of the Apple SDK platform to use when building.
 #
@@ -153,6 +158,7 @@ aarch64-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -211,6 +217,7 @@ armv7-unknown-linux-gnueabi:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -264,6 +271,7 @@ armv7-unknown-linux-gnueabihf:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -317,6 +325,7 @@ loongarch64-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
     - '-Wl,-z,max-page-size=0x10000'
   needs:
     - autoconf
@@ -371,6 +380,7 @@ mips-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -424,6 +434,7 @@ mipsel-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -477,6 +488,7 @@ ppc64le-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -530,6 +542,7 @@ riscv64-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -585,6 +598,7 @@ s390x-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -703,6 +717,7 @@ x86_64-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -766,6 +781,7 @@ x86_64_v2-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -829,6 +845,7 @@ x86_64_v3-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -894,6 +911,7 @@ x86_64_v4-unknown-linux-gnu:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -951,6 +969,7 @@ x86_64-unknown-linux-musl:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -1008,6 +1027,7 @@ x86_64_v2-unknown-linux-musl:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -1065,6 +1085,7 @@ x86_64_v3-unknown-linux-musl:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -1124,6 +1145,7 @@ x86_64_v4-unknown-linux-musl:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb
@@ -1183,6 +1205,7 @@ aarch64-unknown-linux-musl:
     - '-Wl,-z,noexecstack'
     - '-Wl,-z,relro'
     - '-Wl,-z,now'
+    - '-Wl,--build-id=sha1'
   needs:
     - autoconf
     - bdb


### PR DESCRIPTION
Linux distributions built here carry no `.note.gnu.build-id`. That makes them
invisible to debuginfod: the protocol is keyed entirely on that ID, so a debugger
reading one of these binaries has nothing to ask with, and no symbol server —
yours or anyone else's — ever receives a request. This adds
`-Wl,--build-id=sha1` to `target_ldflags` for the Linux targets. Refs #522.

`sha1` rather than `uuid`: it is derived from the linked content, so it does not
affect build reproducibility.

## What I measured

`.note.gnu.build-id` in `install_only_stripped` artifacts:

| release | target | build ID |
|---|---|---|
| 20250205 (3.12.9) | aarch64 | present — `54c37326ccd9e6e2e10a1c0857b5977aecfdc103` |
| 20250612, 20250626, **20250630** | aarch64 | present |
| **20250702**, 20250807, 20250828, 20251010 | aarch64 | absent |
| 20260814 (3.13.15) | aarch64 | absent |
| 20250630, 20250702 (3.12.11) | x86_64 | absent |
| 20260814 (3.10.21 / 3.12.14 / 3.13.15) | x86_64 | absent |

Two separate things, worth separating:

- **x86_64 never had build IDs**, on either side of that window.
- **aarch64 lost them between 20250630 and 20250702**, which lines up with
  21cf744dd ("Enable native builds on Linux aarch64"). Before it, aarch64 was
  cross-compiled with a host toolchain; afterwards it uses the in-tree one, as
  x86_64 always did.

