### PR TITLE
Fix invalid escape sequences in the OpenSSL props literals (`cpython-windows/build.py`)

### DIFF
--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -335,7 +335,7 @@ def apply_source_patch(cpython_source_path: pathlib.Path, patch_path: pathlib.Pa
         normalized_patch.unlink()
 
 
-OPENSSL_PROPS_REMOVE_RULES_LEGACY = b"""
+OPENSSL_PROPS_REMOVE_RULES_LEGACY = rb"""
   <ItemGroup>
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).pdb" />
@@ -350,7 +350,7 @@ OPENSSL_PROPS_REMOVE_RULES_LEGACY = b"""
   </Target>
 """
 
-OPENSSL_PROPS_REMOVE_RULES = b"""
+OPENSSL_PROPS_REMOVE_RULES = rb"""
   <ItemGroup>
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).pdb" />


### PR DESCRIPTION
[`OPENSSL_PROPS_REMOVE_RULES`](https://github.com/astral-sh/python-build-standalone/blob/8ef44c21fabf42ebeed646a40674dab919892c33/cpython-windows/build.py#L353-L370) and [`OPENSSL_PROPS_REMOVE_RULES_LEGACY`](https://github.com/astral-sh/python-build-standalone/blob/8ef44c21fabf42ebeed646a40674dab919892c33/cpython-windows/build.py#L338-L351) are non-raw bytes literals containing `\libcrypto` and `\libssl` and Python reads `\l` as an escape sequence.

Running any build triggers it:

```
cpython-windows/build.py:340: SyntaxWarning: invalid escape sequence '\l'
  <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
cpython-windows/build.py:355: SyntaxWarning: invalid escape sequence '\l'
```

The build still works alright - an unrecognised escape is left as the literal characters. At this stage it is more of a cleanup as nothing broken. It reduces the number of warnings that would otherwise be picked by build monitor. If invalid escapes are ever promoted to an error as suggested in 3.12 [changelog](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes), the build will fail. 

The fix is straightforw - mark both literals raw fixes it.