### PR TITLE
Windows builds cannot hardlink from uv's cache, falling back to full copies

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,8 @@ concurrency:
 
 env:
   FORCE_COLOR: 1
+  # Keep uv's cache on the same volume as the workspace so uv can hardlink
+  UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
 permissions: { }
 


### PR DESCRIPTION
On GitHub's Windows runners with standard checkout actions, the checkout lands on `D:` while uv's default cache is on drive `C:`. During the build, this layout results in the following message from uv:

```
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
```

Again, it's a minor Windows build noise issue and maybe a performance hit (cannot quantify, when hitting in my workflow I fixed it at the same time when introduced caching). Reproducible on every Windows run.

Pointing the cache at the workspace puts both on one volume and restores hardlinking:

```diff
env:
  FORCE_COLOR: 1
+ # Keep uv's cache on the same volume as the workspace so uv can hardlink
+ UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
```

I guess the existing behaviour might have come from the times when there was a single drive for the runner, but just not to depend on a particular layout I set the cache location relative to the workspace.