### PR TITLE
include image names in host-tool cache filenames

### DIFF
--- a/cpython-unix/Makefile
+++ b/cpython-unix/Makefile
@@ -56,8 +56,13 @@ include $(OUTDIR)/versions/VERSION.*
 # Always write out expanded Dockerfiles.
 $(shell $(RUN_BUILD) placeholder_archive dockerfiles)
 
+# Host executables are shared only by builds using the same producer image.
+# Native, non-Docker builds must not reuse executables from a container.
+BINUTILS_SUFFIX := $(HOST_PLATFORM)-$(if $(PYBUILD_NO_DOCKER),local,$(DOCKER_IMAGE_GCC))
+HOST_PYTHON_SUFFIX := $(HOST_PLATFORM)-$(if $(PYBUILD_NO_DOCKER),local,$(DOCKER_IMAGE_BUILD))
+
 BASE_TOOLCHAIN_DEPENDS := \
-    $(if $(NEED_BINUTILS),$(OUTDIR)/binutils-$(BINUTILS_VERSION)-$(HOST_PLATFORM).tar) \
+    $(if $(NEED_BINUTILS),$(OUTDIR)/binutils-$(BINUTILS_VERSION)-$(BINUTILS_SUFFIX).tar) \
     $(OUTDIR)/$(CLANG_FILENAME) \
     $(NULL)
 
@@ -72,7 +77,7 @@ PYTHON_DEP_DEPENDS := \
     $(TOOLCHAIN_DEPENDS) \
     $(NULL)
 
-HOST_PYTHON_DEPENDS := $(OUTDIR)/cpython-$(PYTHON_MAJOR_VERSION)-$(CPYTHON_$(PYTHON_MAJOR_VERSION)_VERSION)-$(HOST_PLATFORM).tar
+HOST_PYTHON_DEPENDS := $(OUTDIR)/cpython-$(PYTHON_MAJOR_VERSION)-$(CPYTHON_$(PYTHON_MAJOR_VERSION)_VERSION)-$(HOST_PYTHON_SUFFIX).tar
 
 default: $(OUTDIR)/cpython-$(CPYTHON_$(PYTHON_MAJOR_VERSION)_VERSION)-$(PACKAGE_SUFFIX).tar
 
@@ -81,7 +86,7 @@ $(OUTDIR)/image-%.$(HOST_PLATFORM).tar: $(OUTDIR)/%.Dockerfile
 	$(RUN_BUILD) --toolchain image-$*
 endif
 
-$(OUTDIR)/binutils-$(BINUTILS_VERSION)-$(HOST_PLATFORM).tar: $(OUTDIR)/image-$(DOCKER_IMAGE_GCC).$(HOST_PLATFORM).tar $(HERE)/build-binutils.sh
+$(OUTDIR)/binutils-$(BINUTILS_VERSION)-$(BINUTILS_SUFFIX).tar: $(if $(PYBUILD_NO_DOCKER),,$(OUTDIR)/image-$(DOCKER_IMAGE_GCC).$(HOST_PLATFORM).tar) $(HERE)/build-binutils.sh
 	$(RUN_BUILD) --toolchain --docker-image $(DOCKER_IMAGE_GCC) binutils
 
 $(OUTDIR)/$(CLANG_FILENAME):
@@ -252,7 +257,7 @@ PYTHON_DEPENDS_$(1) := \
     $$(PYTHON_SUPPORT_FILES) \
     $$(OUTDIR)/versions/VERSION.pip \
     $$(OUTDIR)/versions/VERSION.setuptools \
-    $$(OUTDIR)/cpython-$(1)-$$(CPYTHON_$(1)_VERSION)-$$(HOST_PLATFORM).tar \
+    $$(OUTDIR)/cpython-$(1)-$$(CPYTHON_$(1)_VERSION)-$$(HOST_PYTHON_SUFFIX).tar \
     $$(if$$(NEED_AUTOCONF),$$(OUTDIR)/autoconf-$$(AUTOCONF_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BDB),$$(OUTDIR)/bdb-$$(BDB_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BZIP2),$$(OUTDIR)/bzip2-$$(BZIP2_VERSION)-$$(PACKAGE_SUFFIX).tar) \
@@ -282,7 +287,7 @@ ALL_PYTHON_DEPENDS_$(1) = \
     $$(PYTHON_DEPENDS_$(1)) \
     $$(NULL)
 
-$$(OUTDIR)/cpython-$(1)-$$(CPYTHON_$(1)_VERSION)-$$(HOST_PLATFORM).tar: $$(PYTHON_HOST_DEPENDS)
+$$(OUTDIR)/cpython-$(1)-$$(CPYTHON_$(1)_VERSION)-$$(HOST_PYTHON_SUFFIX).tar: $$(PYTHON_HOST_DEPENDS)
 	$$(RUN_BUILD) --docker-image $$(DOCKER_IMAGE_BUILD) cpython-$(1)-host
 
 $$(OUTDIR)/cpython-$$(CPYTHON_$(1)_VERSION)-$$(PACKAGE_SUFFIX).tar: $$(ALL_PYTHON_DEPENDS_$(1))

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -40,6 +40,7 @@ from pythonbuild.utils import (
     clang_toolchain,
     create_tar_from_directory,
     current_host_platform,
+    docker_image_names,
     download_entry,
     get_target_settings,
     get_targets,
@@ -273,6 +274,7 @@ def simple_build(
                 BUILD,
                 host_platform,
                 target_triple,
+                binutils_image=docker_image_names(settings)["gcc"],
                 binutils=install_binutils(host_platform),
                 clang=True,
                 musl="musl" in target_triple,
@@ -289,6 +291,7 @@ def simple_build(
                 f"cpython-{majmin}",
                 host_platform,
                 version=python_host_version,
+                image_name=docker_image_names(settings)["build"],
             )
 
         build_env.copy_file(archive)
@@ -315,7 +318,7 @@ def simple_build(
         build_env.get_tools_archive(dest_archive, tools_path)
 
 
-def build_binutils(client, image, host_platform):
+def build_binutils(client, image, dest_archive):
     """Build binutils in the Docker image."""
     archive = download_entry("binutils", DOWNLOADS_PATH)
 
@@ -332,9 +335,7 @@ def build_binutils(client, image, host_platform):
             environment=env,
         )
 
-        build_env.get_tools_archive(
-            toolchain_archive_path("binutils", host_platform), "host"
-        )
+        build_env.get_tools_archive(dest_archive, "host")
 
 
 def materialize_clang(host_platform: str, target_triple: str):
@@ -353,7 +354,9 @@ def materialize_clang(host_platform: str, target_triple: str):
             dctx.copy_stream(ifh, ofh)
 
 
-def build_musl(client, image, host_platform: str, target_triple: str, build_options):
+def build_musl(
+    settings, client, image, host_platform: str, target_triple: str, build_options
+):
     static = "static" in build_options
     musl = "musl-static" if static else "musl"
     musl_archive = download_entry(musl, DOWNLOADS_PATH)
@@ -363,6 +366,7 @@ def build_musl(client, image, host_platform: str, target_triple: str, build_opti
             BUILD,
             host_platform,
             target_triple,
+            binutils_image=docker_image_names(settings)["gcc"],
             binutils=True,
             clang=True,
             static=False,
@@ -394,6 +398,7 @@ def build_libedit(
                 BUILD,
                 host_platform,
                 target_triple,
+                binutils_image=docker_image_names(settings)["gcc"],
                 binutils=install_binutils(host_platform),
                 clang=True,
                 musl="musl" in target_triple,
@@ -417,6 +422,7 @@ def build_libedit(
 
 
 def build_cpython_host(
+    settings,
     client,
     image,
     entry,
@@ -427,7 +433,7 @@ def build_cpython_host(
     python_source=None,
     entry_name=None,
 ):
-    """Build binutils in the Docker image."""
+    """Build the Python interpreter used by host-side build steps."""
     if not python_source:
         python_version = entry["version"]
         archive = download_entry(entry_name, DOWNLOADS_PATH)
@@ -445,6 +451,7 @@ def build_cpython_host(
             BUILD,
             host_platform,
             target_triple,
+            binutils_image=docker_image_names(settings)["gcc"],
             binutils=install_binutils(host_platform),
             clang=True,
             static="static" in build_options,
@@ -783,6 +790,7 @@ def build_cpython(
                 BUILD,
                 host_platform,
                 target_triple,
+                binutils_image=docker_image_names(settings)["gcc"],
                 binutils=install_binutils(host_platform),
                 clang=True,
                 musl="musl" in target_triple,
@@ -799,7 +807,11 @@ def build_cpython(
 
         # Install the host CPython.
         build_env.install_toolchain_archive(
-            BUILD, entry_name, host_platform, version=python_version
+            BUILD,
+            entry_name,
+            host_platform,
+            version=python_version,
+            image_name=docker_image_names(settings)["build"],
         )
 
         for p in (
@@ -1149,7 +1161,7 @@ def main():
             build_binutils(
                 client,
                 get_image(client, ROOT, BUILD, docker_image, host_platform),
-                host_platform,
+                dest_archive,
             )
 
         elif action == "clang":
@@ -1157,6 +1169,7 @@ def main():
 
         elif action == "musl":
             build_musl(
+                settings,
                 client,
                 get_image(client, ROOT, BUILD, docker_image, host_platform),
                 host_platform,
@@ -1321,6 +1334,7 @@ def main():
             else:
                 entry = DOWNLOADS.get(entry_name, {})
             build_cpython_host(
+                settings,
                 client,
                 get_image(client, ROOT, BUILD, docker_image, host_platform),
                 entry,

--- a/pythonbuild/buildenv.py
+++ b/pythonbuild/buildenv.py
@@ -39,13 +39,14 @@ class ContainerContext:
         copy_file_to_container(source, self.container, dest_path, dest_name)
 
     def install_toolchain_archive(
-        self, build_dir, package_name, host_platform, version=None
+        self, build_dir, package_name, host_platform, version=None, image_name=None
     ):
         entry = DOWNLOADS[package_name]
-        basename = "%s-%s-%s.tar" % (
+        basename = "%s-%s-%s%s.tar" % (
             package_name,
             version or entry["version"],
             host_platform,
+            f"-{image_name}" if image_name else "",
         )
 
         p = build_dir / basename
@@ -73,13 +74,19 @@ class ContainerContext:
         build_dir,
         host_platform,
         target_triple: str,
+        binutils_image: str,
         binutils=False,
         musl=False,
         clang=False,
         static=False,
     ):
         if binutils:
-            self.install_toolchain_archive(build_dir, "binutils", host_platform)
+            self.install_toolchain_archive(
+                build_dir,
+                "binutils",
+                host_platform,
+                image_name=binutils_image,
+            )
 
         if clang:
             self.install_toolchain_archive(
@@ -162,12 +169,14 @@ class TempdirContext:
         shutil.copy(source, dest_dir / dest_name)
 
     def install_toolchain_archive(
-        self, build_dir, package_name, host_platform, version=None
+        self, build_dir, package_name, host_platform, version=None, image_name=None
     ):
-        basename = "%s-%s-%s.tar" % (
+        # Image-qualified tools built without Docker use the local cache instead.
+        basename = "%s-%s-%s%s.tar" % (
             package_name,
             version or DOWNLOADS[package_name]["version"],
             host_platform,
+            "-local" if image_name else "",
         )
 
         p = build_dir / basename
@@ -196,13 +205,16 @@ class TempdirContext:
         build_dir,
         platform,
         target_triple,
+        binutils_image,
         binutils=False,
         musl=False,
         clang=False,
         static=False,
     ):
         if binutils:
-            self.install_toolchain_archive(build_dir, "binutils", platform)
+            self.install_toolchain_archive(
+                build_dir, "binutils", platform, image_name=binutils_image
+            )
 
         if clang:
             self.install_toolchain_archive(

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -79,6 +79,14 @@ def get_target_settings(yaml_path: pathlib.Path, target: str):
     return get_targets(yaml_path)[target]
 
 
+def docker_image_names(settings) -> dict[str, str]:
+    """Select the images used to build dependencies and GCC-hosted tools."""
+    suffix = settings.get("docker_image_suffix", "")
+    # Cross builds share the bare GCC image for their host tools.
+    gcc_suffix = "" if suffix.startswith(".cross") else suffix
+    return {"build": f"build{suffix}", "gcc": f"gcc{gcc_suffix}"}
+
+
 def supported_targets(yaml_path: pathlib.Path):
     """Obtain a set of named targets that we can build."""
     targets = set()
@@ -195,15 +203,9 @@ def write_triples_makefiles(
                     "NEED_%s := 1\n" % need.upper().replace("-", "_").replace(".", "_")
                 )
 
-            image_suffix = settings.get("docker_image_suffix", "")
-
-            # On cross builds, we can just use the bare `gcc` image
-            gcc_image_suffix = (
-                image_suffix if not image_suffix.startswith(".cross") else ""
-            )
-
-            lines.append("DOCKER_IMAGE_BUILD := build%s\n" % image_suffix)
-            lines.append("DOCKER_IMAGE_GCC := gcc%s\n" % gcc_image_suffix)
+            images = docker_image_names(settings)
+            lines.append("DOCKER_IMAGE_BUILD := %s\n" % images["build"])
+            lines.append("DOCKER_IMAGE_GCC := %s\n" % images["gcc"])
 
             entry = clang_toolchain(host_platform, triple)
             lines.append(


### PR DESCRIPTION
Include the Docker image used to produce binutils and host CPython in their cached archive filenames under build/.

This prevents builds using different images from sharing cached host executables, which are not guaranteed to run in another image. Non-Docker builds, including macOS, use the 'local' suffix.

For example, without this change:

1. A native x86-64 build creates host CPython in the Jessie-based image.
2. An ARMv7 cross-build rebuilds host CPython in the Stretch-based image, overwriting the same cached archive.
3. A subsequent native would re-use the Stretch based host CPython.

Both builds currently use the same cache filename: 
`build/cpython-3.14-3.14.7-linux_x86_64.tar`

With this change, the archives have separate filenames: 
`build/cpython-3.14-3.14.7-linux_x86_64-build.tar`
`build/cpython-3.14-3.14.7-linux_x86_64-build.cross.tar`