### PR TITLE
Authenticate Jessie package downloads

### DIFF
--- a/cpython-unix/base.Dockerfile
+++ b/cpython-unix/base.Dockerfile
@@ -17,17 +17,31 @@ ENV HOME=/build \
 CMD ["/bin/bash", "--login"]
 WORKDIR '/build'
 
-# Jessie's signing keys expired in late 2022. So need to add [trusted=yes] to force trust.
-# Jessie stopped publishing snapshots in March 2023.
-RUN for s in debian_jessie debian_jessie-updates debian-security_jessie/updates; do \
+# Jessie's archive signing keys have expired. Authenticate the immutable package
+# indexes with SHA-256 instead; APT checks each downloaded package against them.
+# These images run on amd64, including the cross-compilation toolchains.
+# Do not refresh these indexes with apt-get update: trusted=yes is safe only
+# with the pinned indexes below. See docs/building.rst for the trust chain.
+RUN rm -rf /var/lib/apt/lists/* && \
+    for s in debian_jessie debian_jessie-updates debian-security_jessie/updates; do \
       echo "deb [trusted=yes] http://snapshot.debian.org/archive/${s%_*}/20230322T152120Z/ ${s#*_} main"; \
     done > /etc/apt/sources.list && \
     ( echo 'quiet "true";'; \
       echo 'APT::Get::Assume-Yes "true";'; \
       echo 'APT::Install-Recommends "false";'; \
-      echo 'Acquire::Check-Valid-Until "false";'; \
       echo 'Acquire::Retries "5";'; \
+      echo 'APT::Update::Pre-Invoke { "echo Jessie indexes are pinned in base.Dockerfile >&2; exit 1"; };'; \
     ) > /etc/apt/apt.conf.d/99cpython-portable
+
+{% for repository, suite, sha256 in [
+    ('debian', 'jessie', '7240a1c6ce11c3658d001261e77797818e610f7da6c2fb1f98a24fdbf4e8d84c'),
+    ('debian', 'jessie-updates', 'f61f27bd17de546264aa58f40f3aafaac7021e0ef69c17f6b1b4cd7664a037ec'),
+    ('debian-security', 'jessie/updates', '3da1205c671e38db711a76403b27f1b3e0b84766edcf717a4b9daea9d4c693b2'),
+] %}
+ADD --checksum=sha256:{{ sha256 }} \
+    https://snapshot.debian.org/archive/{{ repository }}/20230322T152120Z/dists/{{ suite }}/main/binary-amd64/Packages.gz \
+    /var/lib/apt/lists/snapshot.debian.org_archive_{{ repository }}_20230322T152120Z_dists_{{ suite | replace('/', '_') }}_main_binary-amd64_Packages.gz
+{% endfor %}
 
 # apt iterates all available file descriptors up to rlim_max and calls
 # fcntl(fd, F_SETFD, FD_CLOEXEC). This can result in millions of system calls
@@ -37,4 +51,9 @@ RUN for s in debian_jessie debian_jessie-updates debian-security_jessie/updates;
 # Attempts at enforcing the limit globally via /etc/security/limits.conf and
 # /root/.bashrc were not successful. Possibly because container image builds
 # don't perform a login or use a shell the way we expect.
-RUN ulimit -n 10000 && apt-get update
+#
+# The pinned base lacks HTTPS support. Bootstrap it using the authenticated
+# package hashes, then use HTTPS for all subsequent package downloads.
+RUN ulimit -n 10000 && \
+    apt-get install apt-transport-https ca-certificates && \
+    sed -i 's|http://snapshot.debian.org|https://snapshot.debian.org|' /etc/apt/sources.list

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -56,6 +56,41 @@ Or on an x86-64 host for different architectures::
     $ ./build.py --target-triple riscv64-unknown-linux-gnu
     $ ./build.py --target-triple s390x-unknown-linux-gnu
 
+Jessie image package authentication
+-----------------------------------
+
+The ``build``, ``gcc``, and ``rust`` Dockerfiles include
+``cpython-unix/base.Dockerfile``. These amd64 images use Debian Jessie
+for build compatibility. Cross-compilation targets also use the ``gcc``
+image for toolchain builds.
+
+Building these images requires Docker Buildx with support for Dockerfile
+1.6's ``ADD --checksum`` instruction.
+
+The base Dockerfile pins the SHA-256 digests of the three archived
+``Packages.gz`` indexes because Jessie's archive signing keys have expired.
+Docker fetches them over HTTPS and verifies their digests before APT uses
+them. APT then verifies downloaded packages against the hashes in these
+fixed indexes. ``trusted=yes`` permits this separate trust root;
+``apt-get update`` is blocked to prevent replacing the pinned indexes with
+unauthenticated metadata.
+
+The pinned base image lacks both ``apt-transport-https`` and
+``ca-certificates``. Their bootstrap download uses HTTP, authenticated by
+the pinned package hashes. Once they are installed, subsequent package
+downloads use HTTPS with certificate verification.
+
+The index digests come from the SHA256 sections of the archived
+`Jessie Release <https://snapshot.debian.org/archive/debian/20230322T152120Z/dists/jessie/Release>`_,
+`Jessie updates Release <https://snapshot.debian.org/archive/debian/20230322T152120Z/dists/jessie-updates/Release>`_, and
+`Jessie security Release <https://snapshot.debian.org/archive/debian-security/20230322T152120Z/dists/jessie/updates/Release>`_
+files. The corresponding archive key fingerprints in the digest-pinned
+base image are ``126C0D24BD8A2942CC7DF8AC7638D0442B90D010``
+for Jessie and Jessie updates, and
+``D21169141CECD440F2EB8DDA9D6D8F6BC857C906`` for Jessie security. Any change
+to the snapshot or index digests requires independently authenticating the
+replacement metadata.
+
 macOS
 =====
 


### PR DESCRIPTION
Jessie's build images fetch APT metadata over HTTP with `trusted=yes`. An intercepted download can replace both the package index and the packages used to build Python.

Pin the three archived package indexes with SHA-256 and download them over HTTPS. APT verifies packages against those indexes, including during the bootstrap of HTTPS support. Block `apt-get update` from replacing the pinned indexes, then use HTTPS for subsequent package downloads. This preserves the existing snapshot despite its expired signing keys.

Requires Dockerfile 1.6 support for `ADD --checksum`.
